### PR TITLE
chore: ver bump + clean dep groups + clean PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,4 +16,3 @@
 - [ ] `make deps.check`
 
 ## Notes
-<!-- Anything reviewers should know -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ authors = [
   { name = "Seth Barrett" }
 ]
 dependencies = [
-  "PyYAML>=6.0.2",
-  "pydantic>=2.13.0",
+  "PyYAML>=6.0.2,<7",
+  "pydantic>=2.13.0,<3",
 ]
 
 [project.scripts]
@@ -22,11 +22,11 @@ capex = "capex.cli:main"
 
 [dependency-groups]
 dev = [
-  "ruff>=0.15.12",
-  "pytest>=9.0.3",
-  "pytest-cov>=6.0.0",
-  "deptry>=0.25.1",
-  "twine>=6.2.0",
+  "ruff>=0.15.12,<1",
+  "pytest>=9.0.3,<10",
+  "pytest-cov>=6.0.0,<7",
+  "deptry>=0.25.1,<1",
+  "twine>=6.2.0,<7",
 ]
 scripting = [
     "cicflowmeter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "capex"
-version = "1.0.5"
+version = "1.0.6"
 description = "Config-driven network attack capture orchestration for security research"
 readme = "README.md"
 requires-python = ">=3.14"
@@ -21,16 +21,10 @@ dependencies = [
 capex = "capex.cli:main"
 
 [dependency-groups]
-lint = [
+dev = [
   "ruff>=0.15.12",
-]
-test = [
   "pytest>=9.0.3",
   "pytest-cov>=6.0.0",
-]
-dev = [
-  { include-group = "lint" },
-  { include-group = "test" },
   "deptry>=0.25.1",
   "twine>=6.2.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "capex"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -33,9 +33,6 @@ dev = [
     { name = "ruff" },
     { name = "twine" },
 ]
-lint = [
-    { name = "ruff" },
-]
 scripting = [
     { name = "cicflowmeter" },
     { name = "deptry" },
@@ -45,38 +42,29 @@ scripting = [
     { name = "ruff" },
     { name = "twine" },
 ]
-test = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
 
 [package.metadata]
 requires-dist = [
-    { name = "pydantic", specifier = ">=2.13.0" },
-    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "pydantic", specifier = ">=2.13.0,<3" },
+    { name = "pyyaml", specifier = ">=6.0.2,<7" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "deptry", specifier = ">=0.25.1" },
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
-    { name = "ruff", specifier = ">=0.15.12" },
-    { name = "twine", specifier = ">=6.2.0" },
+    { name = "deptry", specifier = ">=0.25.1,<1" },
+    { name = "pytest", specifier = ">=9.0.3,<10" },
+    { name = "pytest-cov", specifier = ">=6.0.0,<7" },
+    { name = "ruff", specifier = ">=0.15.12,<1" },
+    { name = "twine", specifier = ">=6.2.0,<7" },
 ]
-lint = [{ name = "ruff", specifier = ">=0.15.12" }]
 scripting = [
     { name = "cicflowmeter", git = "https://github.com/sethbarrett50/cicflowmeter" },
-    { name = "deptry", specifier = ">=0.25.1" },
+    { name = "deptry", specifier = ">=0.25.1,<1" },
     { name = "pandas", specifier = "==3.0.2" },
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
-    { name = "ruff", specifier = ">=0.15.12" },
-    { name = "twine", specifier = ">=6.2.0" },
-]
-test = [
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest", specifier = ">=9.0.3,<10" },
+    { name = "pytest-cov", specifier = ">=6.0.0,<7" },
+    { name = "ruff", specifier = ">=0.15.12,<1" },
+    { name = "twine", specifier = ">=6.2.0,<7" },
 ]
 
 [[package]]
@@ -611,16 +599,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.1.0"
+version = "6.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4c/f883ab8f0daad69f47efdf95f55a66b51a8b939c430dadce0611508d9e99/pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2", size = 70398, upload-time = "2025-09-06T15:40:14.361Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b4/bb7263e12aade3842b938bc5c6958cae79c5ee18992f9b9349019579da0f/pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749", size = 25115, upload-time = "2025-09-06T15:40:12.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Cleans up extra dep groups
- Adds upper bounds for deps
   - Resolves Issue #16 
- Clean PR Template

## Changes
- [ ] Fix
- [ ] Feature
- [x] Docs
- [ ] Refactor
- [ ] CI
- [x] Deps

## Testing
- [x] `make lint`
- [x] `make test`
- [x] `make preflight`
- [x] `make deps.check`
