### PR TITLE
fix: verify tcpdump capture actually starts, add kill fallback on stop

### DIFF
--- a/src/capex/capture.py
+++ b/src/capex/capture.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+import subprocess
+import time
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import subprocess
+from capex.exceptions import CaptureError
 
+if TYPE_CHECKING:
     from pathlib import Path
 
     from capex.runner import CommandRunner
+
+START_CHECK_DELAY_SECONDS = 0.3
+STOP_TIMEOUT_SECONDS = 15
+KILL_TIMEOUT_SECONDS = 5
 
 
 @dataclass(slots=True)
@@ -16,17 +23,37 @@ class TcpdumpCapture:
     runner: CommandRunner
     binary: str = 'tcpdump'
     process: subprocess.Popen[str] | None = None
+    start_check_delay_seconds: float = START_CHECK_DELAY_SECONDS
 
     def start(self, output_path: Path) -> None:
         if self.process is not None:
             raise RuntimeError('tcpdump capture already running')
 
-        self.process = self.runner.popen([self.binary, '-w', str(output_path)])
+        process = self.runner.popen([self.binary, '-w', str(output_path)])
+
+        if self.start_check_delay_seconds > 0:
+            time.sleep(self.start_check_delay_seconds)
+
+        if process.poll() is not None:
+            _, stderr = process.communicate()
+            msg = (
+                f'{self.binary} exited immediately with code {process.returncode} '
+                f'while starting capture to {output_path}: {stderr.strip()}'
+            )
+            raise CaptureError(msg)
+
+        self.process = process
 
     def stop(self) -> None:
         if self.process is None:
             return
 
-        self.process.terminate()
-        self.process.wait(timeout=15)
+        process = self.process
         self.process = None
+
+        process.terminate()
+        try:
+            process.wait(timeout=STOP_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=KILL_TIMEOUT_SECONDS)

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from capex.capture import TcpdumpCapture
+from capex.exceptions import CaptureError
+
+
+class _FakeProcess:
+    def __init__(self, *, exited: bool = False, returncode: int = 1, stderr: str = '') -> None:
+        self._exited = exited
+        self.returncode = returncode if exited else None
+        self._stderr = stderr
+        self.terminate_called = False
+        self.kill_called = False
+        self._wait_calls = 0
+        self._timeout_on_first_wait = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def communicate(self) -> tuple[str, str]:
+        return '', self._stderr
+
+    def terminate(self) -> None:
+        self.terminate_called = True
+
+    def kill(self) -> None:
+        self.kill_called = True
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        self._wait_calls += 1
+        if self._timeout_on_first_wait and self._wait_calls == 1:
+            raise subprocess.TimeoutExpired(cmd='tcpdump', timeout=timeout or 0)
+        self.returncode = self.returncode if self.returncode is not None else -15
+        return self.returncode
+
+
+class _FakeRunner:
+    def __init__(self, process: _FakeProcess) -> None:
+        self._process = process
+        self.popen_args: list[str] | None = None
+
+    def popen(self, args, *, cwd=None):
+        self.popen_args = list(args)
+        return self._process
+
+
+def test_start_succeeds_when_process_stays_alive(tmp_path) -> None:
+    process = _FakeProcess(exited=False)
+    runner = _FakeRunner(process)
+    capture = TcpdumpCapture(runner=runner, start_check_delay_seconds=0)
+
+    capture.start(tmp_path / 'out.pcap')
+
+    assert capture.process is process
+    assert runner.popen_args[0] == 'tcpdump'
+
+
+def test_start_raises_capture_error_when_process_exits_immediately(tmp_path) -> None:
+    process = _FakeProcess(exited=True, returncode=1, stderr='tcpdump: eth9: No such device exists')
+    runner = _FakeRunner(process)
+    capture = TcpdumpCapture(runner=runner, start_check_delay_seconds=0)
+
+    with pytest.raises(CaptureError, match='No such device exists'):
+        capture.start(tmp_path / 'out.pcap')
+
+    assert capture.process is None
+
+
+def test_stop_terminates_running_process() -> None:
+    process = _FakeProcess(exited=False)
+    capture = TcpdumpCapture(runner=_FakeRunner(process), process=process)
+
+    capture.stop()
+
+    assert process.terminate_called is True
+    assert process.kill_called is False
+    assert capture.process is None
+
+
+def test_stop_kills_process_that_does_not_terminate_in_time() -> None:
+    process = _FakeProcess(exited=False)
+    process._timeout_on_first_wait = True
+    capture = TcpdumpCapture(runner=_FakeRunner(process), process=process)
+
+    capture.stop()
+
+    assert process.terminate_called is True
+    assert process.kill_called is True
+    assert capture.process is None
+
+
+def test_stop_is_a_noop_when_no_process_is_running() -> None:
+    process = _FakeProcess(exited=False)
+    capture = TcpdumpCapture(runner=_FakeRunner(process))
+
+    capture.stop()
+
+    assert process.terminate_called is False


### PR DESCRIPTION
Fixes #51.

## Problem
`TcpdumpCapture.start()` launched tcpdump via `Popen` and never checked whether it actually stayed running. A failure (bad interface, permission denied, etc.) would silently produce an empty pcap while the attack schedule and logs still completed normally — a serious risk for a tool whose whole purpose is producing capture datasets.

`stop()` also had no fallback if `terminate()` didn't complete within its 15s timeout — `wait()` would raise an uncaught `subprocess.TimeoutExpired`.

## Change
- `start()` now does a short poll after launching tcpdump; if the process has already exited, it raises `CaptureError` (from the existing-but-previously-unused `exceptions.py`) including the captured stderr, instead of continuing silently.
- `stop()` now falls back to `kill()` if `terminate()` doesn't complete within the timeout.
- Added `tests/test_capture.py` covering both new behaviors plus the existing start/stop lifecycle, using a fake process double (no real `tcpdump` binary needed in CI). Coverage on `capture.py` went from 56% to 95%.

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest -q` (14 passed)