### PR TITLE
fix: reject enabled placeholder attacks at config-validation time

### DIFF
--- a/src/capex/validation.py
+++ b/src/capex/validation.py
@@ -50,6 +50,11 @@ def validate_attacks(attacks: list[AttackConfig]) -> None:
         msg = f'Duplicate attack names found: {", ".join(sorted(duplicate_names))}'
         raise ConfigError(msg)
 
+    for attack in attacks:
+        if attack.kind == 'placeholder' and attack.enabled:
+            msg = f'Placeholder attack "{attack.name}" cannot be enabled: {attack.reason}'
+            raise ConfigError(msg)
+
     enabled_attacks = [attack for attack in attacks if attack.enabled]
     if not enabled_attacks:
         raise ConfigError('No attacks are enabled.')

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import pytest
 
-from capex.exceptions import ValidationError
-from capex.models import CaptureConfig
-from capex.validation import validate_capture_config
+from capex.exceptions import ConfigError, ValidationError
+from capex.models import CaptureConfig, CommandAttackConfig, PlaceholderAttackConfig
+from capex.validation import validate_attacks, validate_capture_config
 
 
 def test_validate_capture_config_rejects_large_safe_period() -> None:
@@ -15,3 +15,55 @@ def test_validate_capture_config_rejects_large_safe_period() -> None:
 
     with pytest.raises(ValidationError):
         validate_capture_config(config)
+
+
+def _command_attack(name: str = 'attack', *, enabled: bool = True) -> CommandAttackConfig:
+    return CommandAttackConfig(
+        name=name,
+        label=name,
+        enabled=enabled,
+        command=['echo', 'hi'],
+    )
+
+
+def test_validate_attacks_rejects_empty_list() -> None:
+    with pytest.raises(ConfigError, match='No attacks were configured'):
+        validate_attacks([])
+
+
+def test_validate_attacks_rejects_duplicate_names() -> None:
+    attacks = [_command_attack('dup'), _command_attack('dup')]
+
+    with pytest.raises(ConfigError, match='Duplicate attack names'):
+        validate_attacks(attacks)
+
+
+def test_validate_attacks_rejects_no_enabled_attacks() -> None:
+    attacks = [_command_attack('a', enabled=False)]
+
+    with pytest.raises(ConfigError, match='No attacks are enabled'):
+        validate_attacks(attacks)
+
+
+def test_validate_attacks_accepts_disabled_placeholder() -> None:
+    attacks = [
+        _command_attack('a'),
+        PlaceholderAttackConfig(name='legacy', label='legacy', reason='not implemented'),
+    ]
+
+    validate_attacks(attacks)
+
+
+def test_validate_attacks_rejects_enabled_placeholder() -> None:
+    attacks = [
+        _command_attack('a'),
+        PlaceholderAttackConfig(
+            name='legacy',
+            label='legacy',
+            enabled=True,
+            reason='not implemented',
+        ),
+    ]
+
+    with pytest.raises(ConfigError, match='cannot be enabled'):
+        validate_attacks(attacks)


### PR DESCRIPTION
Fixes #52.

## Problem
`PlaceholderAttackExecutor.execute()` unconditionally raises `RuntimeError` whenever it's called. Nothing previously stopped a `kind: placeholder` attack from being configured with `enabled: true` in `attacks.yaml` (its default is `enabled: false`, but that's not enforced). If one was enabled, the scheduler would hit it mid-capture — potentially hours into an unattended run — and the resulting exception would propagate out of `CaptureSession.run()`, killing the whole session and losing all data collected for that device.

## Change
`validate_attacks()` now rejects an enabled placeholder attack at config-validation time (before `ensure_capture_directories`/capture start), raising `ConfigError` with the placeholder's `reason` in the message, instead of letting it fail live mid-capture.

Also added direct tests for `validate_attacks()`'s other rules (empty list, duplicate names, no enabled attacks) that had no coverage before — this function was at 21% coverage (see #60).

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest -q` (19 passed)