### PR TITLE
fix: spread each attack's repeats independently across the full capture window

### DIFF
--- a/src/capex/scheduler.py
+++ b/src/capex/scheduler.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 @dataclass(slots=True, frozen=True)
@@ -12,27 +16,30 @@ class ScheduledAttack:
 
 def build_schedule(
     *,
-    attack_count: int,
-    repeats_per_attack: int,
+    repeats_per_attack: Sequence[int],
     allowed_duration_seconds: int,
 ) -> list[ScheduledAttack]:
-    total = attack_count * repeats_per_attack
-    if total <= 0:
-        return []
+    """Build a schedule spreading each attack's repeats evenly across the full duration.
 
-    interval = allowed_duration_seconds / total
+    Each attack's repeats are spaced independently over the whole
+    ``allowed_duration_seconds`` window, so attacks with fewer repeats than
+    others are not clustered into the earliest part of the run.
+    """
     schedule: list[ScheduledAttack] = []
 
-    counter = 0
-    for attack_index in range(attack_count):
-        for repeat_index in range(repeats_per_attack):
+    for attack_index, repeats in enumerate(repeats_per_attack):
+        if repeats <= 0:
+            continue
+
+        interval = allowed_duration_seconds / repeats
+        for repeat_index in range(repeats):
             schedule.append(
                 ScheduledAttack(
-                    offset_seconds=counter * interval,
+                    offset_seconds=repeat_index * interval,
                     attack_index=attack_index,
                     repeat_index=repeat_index,
                 )
             )
-            counter += 1
 
+    schedule.sort(key=lambda item: item.offset_seconds)
     return schedule

--- a/src/capex/services/capture_session.py
+++ b/src/capex/services/capture_session.py
@@ -69,10 +69,8 @@ class CaptureSession:
             LOGGER.warning('No enabled attacks for device %s', device.name)
             return
 
-        repeats = max(attack.repeats for attack in enabled_attacks)
         schedule = build_schedule(
-            attack_count=len(enabled_attacks),
-            repeats_per_attack=repeats,
+            repeats_per_attack=[attack.repeats for attack in enabled_attacks],
             allowed_duration_seconds=allowed,
         )
 
@@ -81,8 +79,6 @@ class CaptureSession:
         with log_path.open('w', encoding='utf-8') as handle:
             for item in schedule:
                 attack = enabled_attacks[item.attack_index]
-                if item.repeat_index >= attack.repeats:
-                    continue
 
                 target_time = started_at + item.offset_seconds
                 sleep_for = target_time - time.time()

--- a/tests/test_capture_session.py
+++ b/tests/test_capture_session.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from capex.models import CaptureConfig, CommandAttackConfig, DeviceConfig
+from capex.services.capture_session import CaptureSession
+
+
+class _RecordingRunner:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def run(self, args, *, check=True, cwd=None):
+        self.calls.append(list(args))
+
+
+def test_run_attacks_invokes_each_attack_exactly_its_configured_repeats(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr('capex.services.capture_session.time.sleep', lambda _seconds: None)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    config = CaptureConfig(
+        duration_seconds=100,
+        safe_period_seconds=10,
+        output_dir=tmp_path,
+        log_dir=tmp_path,
+    )
+    runner = _RecordingRunner()
+    session = CaptureSession(runner=runner, config=config)
+
+    few_repeats = CommandAttackConfig(
+        name='few',
+        label='few',
+        repeats=2,
+        command=['echo', 'few'],
+    )
+    many_repeats = CommandAttackConfig(
+        name='many',
+        label='many',
+        repeats=4,
+        command=['echo', 'many'],
+    )
+
+    log_path = tmp_path / 'dev1_CE.txt'
+    session._run_attacks(
+        device=device,
+        attacks=[few_repeats, many_repeats],
+        log_path=log_path,
+    )
+
+    few_calls = [call for call in runner.calls if call[1] == 'few']
+    many_calls = [call for call in runner.calls if call[1] == 'many']
+
+    assert len(few_calls) == 2
+    assert len(many_calls) == 4

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -5,8 +5,39 @@ from capex.scheduler import build_schedule
 
 def test_build_schedule_count() -> None:
     schedule = build_schedule(
-        attack_count=4,
-        repeats_per_attack=3,
+        repeats_per_attack=[3, 3, 3, 3],
         allowed_duration_seconds=120,
     )
     assert len(schedule) == 12
+
+
+def test_build_schedule_spreads_uneven_repeats_across_full_duration() -> None:
+    # Attack 0 has far fewer repeats than attack 1. Previously, attack 0's
+    # runs would all cluster in the first repeat-index rounds instead of
+    # being spread across the whole window.
+    schedule = build_schedule(
+        repeats_per_attack=[2, 10],
+        allowed_duration_seconds=100,
+    )
+
+    attack_0_offsets = [item.offset_seconds for item in schedule if item.attack_index == 0]
+    assert attack_0_offsets == [0.0, 50.0]
+
+    # The schedule as a whole must be sorted by offset regardless of which
+    # attack contributed each entry.
+    offsets = [item.offset_seconds for item in schedule]
+    assert offsets == sorted(offsets)
+
+
+def test_build_schedule_skips_attacks_with_zero_repeats() -> None:
+    schedule = build_schedule(
+        repeats_per_attack=[0, 2],
+        allowed_duration_seconds=100,
+    )
+
+    assert all(item.attack_index == 1 for item in schedule)
+    assert len(schedule) == 2
+
+
+def test_build_schedule_empty_when_no_attacks() -> None:
+    assert build_schedule(repeats_per_attack=[], allowed_duration_seconds=100) == []


### PR DESCRIPTION
Fixes #53.

## Problem
`build_schedule()` built a single `attack_count * max(repeats)` grid evenly spread over the capture window, then `CaptureSession._run_attacks()` skipped any slot where `repeat_index >= attack.repeats`. For attacks with fewer repeats than the max, this meant all of their runs landed in the *earliest* repeat-index rounds rather than being spread proportionally across the full duration — e.g. with repeats `[3, 10]`, the repeats=3 attack's 3 runs all fell within the first 3 of 10 evenly-spaced rounds (roughly the first 30% of the window), instead of across the whole capture.

For a dataset meant to support concept-drift research, this biases the temporal distribution of attack traffic in a way that isn't obvious from the config.

## Change
`build_schedule()` now takes a `repeats_per_attack: Sequence[int]` (one count per attack) instead of a single shared `repeats_per_attack: int`, computes each attack's own even spacing over `allowed_duration_seconds` independently, then merges and sorts all attacks' entries by offset. `CaptureSession._run_attacks()` no longer needs the `repeat_index >= attack.repeats` skip, since every generated entry is valid by construction.

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest -q` (23 passed)
- New `tests/test_scheduler.py::test_build_schedule_spreads_uneven_repeats_across_full_duration` directly asserts a 2-repeat attack's offsets land at `[0, 50]` (not clustered at the start) when paired with a 10-repeat attack over a 100s window.
- New `tests/test_capture_session.py` exercises `_run_attacks()` end-to-end with a recording fake runner, confirming each attack fires exactly its configured repeat count.
- Coverage: `scheduler.py` 95%→100%, `services/capture_session.py` 27%→72%.