### PR TITLE
fix: wire up custom exception hierarchy instead of raising builtin exceptions

### DIFF
--- a/src/capex/attacks/builtins.py
+++ b/src/capex/attacks/builtins.py
@@ -4,6 +4,8 @@ import time
 
 from typing import TYPE_CHECKING
 
+from capex.exceptions import AttackExecutionError
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -49,4 +51,4 @@ class PlaceholderAttackExecutor:
         device: DeviceConfig,
         log_path: Path,
     ) -> None:
-        raise RuntimeError(f'Attack "{self._attack.name}" is disabled: {self._attack.reason}')
+        raise AttackExecutionError(f'Attack "{self._attack.name}" is disabled: {self._attack.reason}')

--- a/src/capex/attacks/registry.py
+++ b/src/capex/attacks/registry.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
 from capex.attacks.hulk import HulkAttackExecutor
+from capex.exceptions import RegistryError
 
 if TYPE_CHECKING:
     from capex.attacks.base import BoundAttackExecutor
@@ -32,4 +33,4 @@ class AttackRegistry:
                 )
             case _:
                 msg = f'Unsupported attack kind: {attack.kind}'
-                raise ValueError(msg)
+                raise RegistryError(msg)

--- a/src/capex/capture.py
+++ b/src/capex/capture.py
@@ -27,7 +27,7 @@ class TcpdumpCapture:
 
     def start(self, output_path: Path) -> None:
         if self.process is not None:
-            raise RuntimeError('tcpdump capture already running')
+            raise CaptureError('tcpdump capture already running')
 
         process = self.runner.popen([self.binary, '-w', str(output_path)])
 

--- a/src/capex/config.py
+++ b/src/capex/config.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
+from capex.exceptions import ConfigError
 from capex.models import AttackFile, DeviceFile
 
 if TYPE_CHECKING:
@@ -16,7 +17,7 @@ def _load_yaml(path: Path) -> dict[str, Any]:
 
     if not isinstance(data, dict):
         msg = f'Expected mapping at top level in {path}'
-        raise ValueError(msg)
+        raise ConfigError(msg)
 
     return data
 

--- a/src/capex/runner.py
+++ b/src/capex/runner.py
@@ -6,6 +6,8 @@ import subprocess
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from capex.exceptions import CommandExecutionError
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
@@ -47,7 +49,7 @@ class CommandRunner:
         if check and proc.returncode != 0:
             LOGGER.error('Command failed: %s', args)
             msg = f'Command failed with exit code {proc.returncode}: {args!r}'
-            raise RuntimeError(msg)
+            raise CommandExecutionError(msg)
 
         return result
 

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+
+from capex.attacks.builtins import PlaceholderAttackExecutor
+from capex.exceptions import AttackExecutionError
+from capex.models import DeviceConfig, PlaceholderAttackConfig
+
+
+def test_placeholder_executor_raises_attack_execution_error(tmp_path) -> None:
+    attack = PlaceholderAttackConfig(name='legacy', label='legacy', reason='not implemented yet')
+    executor = PlaceholderAttackExecutor(attack=attack)
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+
+    with pytest.raises(AttackExecutionError, match='not implemented yet'):
+        executor.execute(device=device, log_path=tmp_path / 'log.txt')

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -60,6 +60,14 @@ def test_start_succeeds_when_process_stays_alive(tmp_path) -> None:
     assert runner.popen_args[0] == 'tcpdump'
 
 
+def test_start_raises_capture_error_when_already_running(tmp_path) -> None:
+    process = _FakeProcess(exited=False)
+    capture = TcpdumpCapture(runner=_FakeRunner(process), process=process)
+
+    with pytest.raises(CaptureError, match='already running'):
+        capture.start(tmp_path / 'out.pcap')
+
+
 def test_start_raises_capture_error_when_process_exits_immediately(tmp_path) -> None:
     process = _FakeProcess(exited=True, returncode=1, stderr='tcpdump: eth9: No such device exists')
     runner = _FakeRunner(process)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from capex.config import load_attacks, load_devices
+from capex.exceptions import ConfigError
+
+
+def test_load_devices_raises_config_error_when_top_level_is_not_a_mapping(tmp_path) -> None:
+    path = tmp_path / 'devices.yaml'
+    path.write_text('- a\n- b\n', encoding='utf-8')
+
+    with pytest.raises(ConfigError, match='Expected mapping'):
+        load_devices(path)
+
+
+def test_load_attacks_raises_config_error_when_top_level_is_not_a_mapping(tmp_path) -> None:
+    path = tmp_path / 'attacks.yaml'
+    path.write_text('- a\n- b\n', encoding='utf-8')
+
+    with pytest.raises(ConfigError, match='Expected mapping'):
+        load_attacks(path)
+
+
+def test_load_devices_parses_valid_file(tmp_path) -> None:
+    path = tmp_path / 'devices.yaml'
+    path.write_text(
+        'devices:\n  - name: dev1\n    ip: 192.168.1.1\n',
+        encoding='utf-8',
+    )
+
+    result = load_devices(path)
+
+    assert result.devices[0].name == 'dev1'

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import types
+
+import pytest
+
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.attacks.registry import AttackRegistry
+from capex.exceptions import RegistryError
 from capex.models import CommandAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
 from capex.runner import CommandRunner
 
@@ -40,3 +45,11 @@ def test_registry_resolves_hulk_attack() -> None:
     )
     resolved = registry.resolve(attack)
     assert isinstance(resolved, HulkAttackExecutor)
+
+
+def test_registry_raises_registry_error_for_unsupported_kind() -> None:
+    registry = AttackRegistry(CommandRunner())
+    attack = types.SimpleNamespace(kind='unsupported')
+
+    with pytest.raises(RegistryError, match='Unsupported attack kind'):
+        registry.resolve(attack)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from capex.exceptions import CommandExecutionError
+from capex.runner import CommandRunner
+
+
+def test_run_raises_command_execution_error_on_nonzero_exit() -> None:
+    runner = CommandRunner()
+
+    with pytest.raises(CommandExecutionError, match='exit code 1'):
+        runner.run([sys.executable, '-c', 'import sys; sys.exit(1)'])
+
+
+def test_run_does_not_raise_when_check_is_false() -> None:
+    runner = CommandRunner()
+
+    result = runner.run([sys.executable, '-c', 'import sys; sys.exit(1)'], check=False)
+
+    assert result.returncode == 1
+
+
+def test_run_returns_completed_command_on_success() -> None:
+    runner = CommandRunner()
+
+    result = runner.run([sys.executable, '-c', "print('hi')"])
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == 'hi'


### PR DESCRIPTION
Fixes #54.

(Note: #65 previously said "Fixes #54" by mistake — a parallel-issue-creation numbering mixup on my end meant #54 and #55 got their content swapped from what I intended. Corrected: #65 actually closed #55 (hulk executor); this PR is the real #54.)

## Problem
`exceptions.py` defines `CommandExecutionError`, `CaptureError`, `AttackExecutionError`, and `RegistryError`, but nothing in the codebase raised them before this change — failures surfaced as generic `RuntimeError`/`ValueError` everywhere except `validation.py` (which already used `ConfigError`/`ValidationError`/`PathError`). Callers couldn't distinguish CAPEX-specific failures from programming bugs.

## Change
Wired the existing exception types into their corresponding raise sites:
- `CommandRunner.run()` → `CommandExecutionError` (was `RuntimeError`)
- `TcpdumpCapture.start()`'s double-start guard → `CaptureError` (was `RuntimeError`; the exited-immediately case already used `CaptureError` from #51)
- `config._load_yaml()` → `ConfigError` (was `ValueError`)
- `PlaceholderAttackExecutor.execute()` → `AttackExecutionError` (was `RuntimeError`)
- `AttackRegistry.resolve()`'s unsupported-kind case → `RegistryError` (was `ValueError`)

Also added test coverage for each of these — three of the five touched modules (`runner.py`, `config.py`, `attacks/builtins.py`) had no dedicated test file at all before this.

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest -q` (35 passed)
- [x] `uv run deptry .` — no issues
- Coverage: 48% → 82% overall; `exceptions.py` now 100%.