### PR TITLE
fix: make CaptureSession the sole writer of the attack log

### DIFF
--- a/src/capex/attacks/base.py
+++ b/src/capex/attacks/base.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from capex.models import DeviceConfig
 
 
 class BoundAttackExecutor(Protocol):
-    def execute(
-        self,
-        *,
-        device: DeviceConfig,
-        log_path: Path,
-    ) -> None: ...
+    def execute(self, *, device: DeviceConfig) -> str | None:
+        """Run the attack against ``device``.
+
+        Returns an optional short, single-line detail string (e.g. a
+        request count) to be appended to the capture session's attack
+        log entry for this invocation. The capture session owns all
+        writes to the attack log; executors must not write to it
+        themselves.
+        """
+        ...

--- a/src/capex/attacks/builtins.py
+++ b/src/capex/attacks/builtins.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-import time
-
 from typing import TYPE_CHECKING
 
 from capex.exceptions import AttackExecutionError
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from capex.models import CommandAttackConfig, DeviceConfig, PlaceholderAttackConfig
     from capex.runner import CommandRunner
 
@@ -23,12 +19,7 @@ class CommandAttackExecutor:
         self._runner = runner
         self._attack = attack
 
-    def execute(
-        self,
-        *,
-        device: DeviceConfig,
-        log_path: Path,
-    ) -> None:
+    def execute(self, *, device: DeviceConfig) -> str | None:
         rendered = [
             token.format(
                 target_ip=str(device.ip),
@@ -37,18 +28,12 @@ class CommandAttackExecutor:
             for token in self._attack.command
         ]
         self._runner.run(rendered)
-        with log_path.open('a', encoding='utf-8') as handle:
-            handle.write(f'attack={self._attack.label} device={device.name} timestamp={time.time()}\n')
+        return None
 
 
 class PlaceholderAttackExecutor:
     def __init__(self, *, attack: PlaceholderAttackConfig) -> None:
         self._attack = attack
 
-    def execute(
-        self,
-        *,
-        device: DeviceConfig,
-        log_path: Path,
-    ) -> None:
+    def execute(self, *, device: DeviceConfig) -> str | None:
         raise AttackExecutionError(f'Attack "{self._attack.name}" is disabled: {self._attack.reason}')

--- a/src/capex/attacks/hulk.py
+++ b/src/capex/attacks/hulk.py
@@ -9,8 +9,6 @@ import urllib.request
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from capex.models import DeviceConfig, HulkAttackConfig
 
 # HULK - HTTP Unbearable Load King: floods a target with randomized,
@@ -80,12 +78,7 @@ class HulkAttackExecutor:
     def __init__(self, *, attack: HulkAttackConfig) -> None:
         self._attack = attack
 
-    def execute(
-        self,
-        *,
-        device: DeviceConfig,
-        log_path: Path,
-    ) -> None:
+    def execute(self, *, device: DeviceConfig) -> str | None:
         target_url = f'http://{device.ip}'
         host = str(device.ip)
         stop_event = threading.Event()
@@ -104,8 +97,4 @@ class HulkAttackExecutor:
             worker.join(timeout=_WORKER_JOIN_TIMEOUT_SECONDS)
 
         total_requests = sum(worker.request_count for worker in workers)
-
-        with log_path.open('a', encoding='utf-8') as handle:
-            handle.write(
-                f'attack={self._attack.label} device={device.name} requests={total_requests} timestamp={time.time()}\n'
-            )
+        return f'requests={total_requests}'

--- a/src/capex/services/capture_session.py
+++ b/src/capex/services/capture_session.py
@@ -87,16 +87,16 @@ class CaptureSession:
 
                 executor = self._registry.resolve(attack)
                 now = time.time()
-                executor.execute(
-                    device=device,
-                    log_path=log_path,
-                )
+                detail = executor.execute(device=device)
 
-                handle.write(
+                line = (
                     'Attack: '
                     f'{attack.label}, '
                     f'Attempt: {item.repeat_index + 1}, '
                     f'Unix Time: {now}, '
-                    f'Time Since Start: {now - started_at}\n'
+                    f'Time Since Start: {now - started_at}'
                 )
+                if detail:
+                    line += f', {detail}'
+                handle.write(line + '\n')
                 handle.flush()

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -7,10 +7,10 @@ from capex.exceptions import AttackExecutionError
 from capex.models import DeviceConfig, PlaceholderAttackConfig
 
 
-def test_placeholder_executor_raises_attack_execution_error(tmp_path) -> None:
+def test_placeholder_executor_raises_attack_execution_error() -> None:
     attack = PlaceholderAttackConfig(name='legacy', label='legacy', reason='not implemented yet')
     executor = PlaceholderAttackExecutor(attack=attack)
     device = DeviceConfig(name='dev1', ip='192.168.1.1')
 
     with pytest.raises(AttackExecutionError, match='not implemented yet'):
-        executor.execute(device=device, log_path=tmp_path / 'log.txt')
+        executor.execute(device=device)

--- a/tests/test_capture_session.py
+++ b/tests/test_capture_session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from capex.models import CaptureConfig, CommandAttackConfig, DeviceConfig
+from capex.attacks import hulk
+from capex.models import CaptureConfig, CommandAttackConfig, DeviceConfig, HulkAttackConfig
 from capex.services.capture_session import CaptureSession
 
 
@@ -50,3 +51,34 @@ def test_run_attacks_invokes_each_attack_exactly_its_configured_repeats(tmp_path
 
     assert len(few_calls) == 2
     assert len(many_calls) == 4
+
+    # The capture session is the sole writer of the attack log - one line
+    # per scheduled attack, in its own format, with no separate writes
+    # from the executors themselves.
+    log_lines = log_path.read_text(encoding='utf-8').splitlines()
+    assert len(log_lines) == 6
+    assert all(line.startswith('Attack: ') for line in log_lines)
+
+
+def test_run_attacks_appends_executor_detail_to_session_log_line(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr('capex.services.capture_session.time.sleep', lambda _seconds: None)
+    monkeypatch.setattr(hulk.time, 'sleep', lambda _seconds: None)
+    monkeypatch.setattr(hulk.urllib.request, 'urlopen', lambda request, timeout=None: None)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    config = CaptureConfig(
+        duration_seconds=100,
+        safe_period_seconds=10,
+        output_dir=tmp_path,
+        log_dir=tmp_path,
+    )
+    session = CaptureSession(runner=_RecordingRunner(), config=config)
+
+    attack = HulkAttackConfig(name='hulk', label='HULK', repeats=1, thread_count=1, duration_seconds=1)
+
+    log_path = tmp_path / 'dev1_CE.txt'
+    session._run_attacks(device=device, attacks=[attack], log_path=log_path)
+
+    (line,) = log_path.read_text(encoding='utf-8').splitlines()
+    assert line.startswith('Attack: HULK, ')
+    assert 'requests=' in line

--- a/tests/test_hulk.py
+++ b/tests/test_hulk.py
@@ -6,7 +6,7 @@ from capex.attacks import hulk
 from capex.models import DeviceConfig, HulkAttackConfig
 
 
-def test_hulk_attack_executor_floods_and_logs_results(tmp_path, monkeypatch) -> None:
+def test_hulk_attack_executor_floods_and_returns_request_count(monkeypatch) -> None:
     call_count = 0
     lock = threading.Lock()
 
@@ -27,17 +27,15 @@ def test_hulk_attack_executor_floods_and_logs_results(tmp_path, monkeypatch) -> 
     )
     executor = hulk.HulkAttackExecutor(attack=attack)
 
-    log_path = tmp_path / 'dev1_CE.txt'
-    executor.execute(device=device, log_path=log_path)
+    detail = executor.execute(device=device)
 
-    content = log_path.read_text(encoding='utf-8')
-    assert 'attack=HULK_HTTP_Flood' in content
-    assert 'device=dev1' in content
-    assert 'requests=' in content
+    assert detail is not None
+    assert detail.startswith('requests=')
     assert call_count > 0
+    assert detail == f'requests={call_count}'
 
 
-def test_hulk_attack_executor_backs_off_on_unreachable_target(tmp_path, monkeypatch) -> None:
+def test_hulk_attack_executor_backs_off_on_unreachable_target(monkeypatch) -> None:
     def failing_urlopen(request, timeout=None):
         raise hulk.urllib.error.URLError('connection refused')
 
@@ -52,8 +50,6 @@ def test_hulk_attack_executor_backs_off_on_unreachable_target(tmp_path, monkeypa
     )
     executor = hulk.HulkAttackExecutor(attack=attack)
 
-    log_path = tmp_path / 'dev1_CE.txt'
-    executor.execute(device=device, log_path=log_path)
+    detail = executor.execute(device=device)
 
-    content = log_path.read_text(encoding='utf-8')
-    assert 'requests=0' in content
+    assert detail == 'requests=0'


### PR DESCRIPTION
Fixes #56.

## Problem
`CaptureSession._run_attacks()` opened `log_path` once in `'w'` mode and wrote a summary line per attack. Independently, `CommandAttackExecutor.execute()` and `HulkAttackExecutor.execute()` *also* opened the same `log_path` in `'a'` mode on every invocation and wrote their own, differently-formatted lines. Two uncoordinated writers to one file, interleaved by attack timing, with incompatible formats.

## Change
`BoundAttackExecutor.execute()` no longer takes `log_path` and no longer writes to the log file. It now returns an optional short detail string (`str | None`) — e.g. `HulkAttackExecutor` returns `"requests=<n>"` — which `CaptureSession` appends to its own single log line for that attack invocation. `CaptureSession` is now the only code that opens or writes to `data/logs/<device>_CE.txt`.

`CommandAttackExecutor` and `PlaceholderAttackExecutor` have nothing extra to report, so they return `None` and the log line is unchanged from before for those attack kinds.

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest -q` (37 passed)
- [x] `uv run deptry .` — no issues
- [x] `uv run python -m capex --dry-run --devices configs/devices.yaml --attacks configs/attacks.yaml` — confirms the config still loads/validates correctly
- New assertions in `tests/test_capture_session.py` confirm the log file has exactly one line per scheduled attack (all in `CaptureSession`'s format) and that an executor's returned detail (HULK's request count) gets appended to that single line.