### PR TITLE
docs: fill in ISSUE_TEMPLATE security-report link placeholder

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Security reports
-    url: https://github.com/<OWNER>/<REPO>/security/advisories/new
+    url: https://github.com/DFAIR-LAB-Augusta/CAPEX/security/advisories/new
     about: Please report vulnerabilities via Security Advisories.


### PR DESCRIPTION
Fixes #57.

## Problem
`.github/ISSUE_TEMPLATE/config.yml`'s "Security reports" contact link still had the literal, unfilled `<OWNER>/<REPO>` placeholder, so clicking it from the "new issue" picker 404s.

## Change
One-line fix: filled in `DFAIR-LAB-Augusta/CAPEX`.

## Test plan
Not code-executable; verified by inspection that the URL now matches the repo.