### PR TITLE
fix: reconcile Makefile targets with README documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ATTACKS ?= configs/attacks.yaml
 DURATION ?= 28800
 SAFE_PERIOD ?= 900
 
-.PHONY: help sync lint format check test run sample build clean
+.PHONY: help sync lint format check test run run-device dry-run build clean preflight flows deps.check
 
 help: ## Show targets
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
@@ -48,7 +48,15 @@ run: ## Run CAPEX with default configs
 		--duration-seconds $(DURATION) \
 		--safe-period-seconds $(SAFE_PERIOD)
 
-run.dry: ## Validate config and print execution plan
+run-device: ## Run CAPEX for a single device (DEVICE=name)
+	$(UV) run python -m capex \
+		--devices $(DEVICES) \
+		--attacks $(ATTACKS) \
+		--duration-seconds $(DURATION) \
+		--safe-period-seconds $(SAFE_PERIOD) \
+		--device $(DEVICE)
+
+dry-run: ## Validate config and print execution plan
 	$(UV) run python -m capex \
 		--dry-run \
 		--devices $(DEVICES) \


### PR DESCRIPTION
Fixes #58.

## Problem
README documented `make dry-run` and `make run-device DEVICE=nestCam`, but the Makefile only defined `run.dry` (different name) and had no `run-device` target at all. Following the README exactly gave `make: *** No rule to make target 'dry-run'.`

## Change
- Renamed `run.dry` → `dry-run` to match the README.
- Added a `run-device` target wiring `DEVICE=` into the CLI's existing `--device` flag.
- Reconciled `.PHONY`: removed a stray `sample` entry (no such target existed) and added `preflight`, `flows`, `deps.check`, which existed but weren't listed.

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest -q` (37 passed)
- [x] `make dry-run` — runs and prints the execution plan correctly.
- [x] `make run-device DEVICE=nestCam` — correctly routes to `--device nestCam`; fails only on `tcpdump` lacking raw-socket permission in this sandbox (unrelated environment limitation, and a nice confirmation that #51's `CaptureError` surfaces that failure clearly instead of silently succeeding).