### PR TITLE
chore: align ruff target-version with pyproject requires-python

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -3,7 +3,7 @@
 # Core settings (top‐level)
 line-length    = 120
 cache-dir      = ".ruff_cache"
-target-version = "py310"
+target-version = "py314"
 unsafe-fixes   = true
 show-fixes     = true
 


### PR DESCRIPTION
Fixes #59.

## Problem
`.ruff.toml` set `target-version = "py310"` while `pyproject.toml` requires `>=3.14`. Ruff was linting/formatting against a syntax baseline four minor versions behind what the package actually supports, which can hide available modernizations and is confusing for contributors trying to figure out the real minimum supported version.

## Change
One-line fix: `target-version = "py314"`.

## Test plan
- [x] `uv run ruff check .` — all checks pass, no new findings from the updated baseline.
- [x] `uv run ruff format --check .` — no reformatting needed.
- [x] `uv run pytest -q` (37 passed)