### PR TITLE
feat: recon/discovery attacks (nmap -sV, SSDP discovery, banner grab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ Each attack is defined by a `kind` field and mapped to an executor:
 
 * `command` executes external binaries such as `nmap` or `hping3`
 * `hulk` runs an in-process HTTP flood (HULK) against the target device; configurable via `duration_seconds` and `thread_count`
+* `ssdp_discovery` sends a unicast SSDP M-SEARCH probe to the target device; configurable via `timeout_seconds`
+* `banner_grab` connects to a device port and reports whatever banner it sends back; configurable via `port`, `timeout_seconds`, and an optional `probe`
 * `placeholder` is a disabled stub for attacks not yet implemented (cannot be `enabled: true`)
 * additional attack types can be added via the registry
 

--- a/configs/attacks.yaml
+++ b/configs/attacks.yaml
@@ -57,6 +57,34 @@ attacks:
     repeats: 3
     duration_seconds: 60
 
+  # Reconnaissance / Discovery (#75)
+  - name: nmap_service_detection
+    label: Nmap_Service_Detection
+    enabled: true
+    repeats: 3
+    command:
+      - nmap
+      - -sV
+      - -p
+      - 1-1000
+      - "{target_ip}"
+
+  - name: ssdp_discovery
+    label: SSDP_Discovery
+    kind: ssdp_discovery
+    enabled: true
+    repeats: 3
+    timeout_seconds: 3
+
+  - name: banner_grab_http
+    label: Banner_Grab_HTTP
+    kind: banner_grab
+    enabled: true
+    repeats: 3
+    port: 80
+    timeout_seconds: 5
+    probe: "HEAD / HTTP/1.0\r\nHost: {target_ip}\r\n\r\n"
+
   # - name: http_request
   #   label: HTTP_Request
   #   enabled: false

--- a/docs/superpowers/specs/2026-09-03-attack-library-expansion-design.md
+++ b/docs/superpowers/specs/2026-09-03-attack-library-expansion-design.md
@@ -1,0 +1,83 @@
+# Attack Library Expansion for MITRE ATT&CK Coverage
+
+Roadmap/design for issue #66. Goal: broaden CAPEX's attack set beyond DoS/flood
+techniques so the multiclass concept-drift IDS work has genuinely distinct,
+*authentic* attack classes to train and evaluate against, captured against
+real lab IoT devices in a sandboxed environment.
+
+## Motivation
+
+Current attacks (`configs/attacks.yaml`) are all Impact/DoS-style floods
+(`xmas_flood`, `tcp_syn_flood`, `udp_flood`, `http_flood`, `hulk_http_flood`)
+plus one reconnaissance scan. That's effectively one MITRE ATT&CK category.
+Public IoT-attack datasets are widely considered weak/unrealistic for this
+kind of research; the explicit goal here is authentic, real-tool-driven
+traffic (real `hydra`, `slowhttptest`, `arpspoof`, etc. against real
+devices) — not synthetic or mocked attack traffic standing in for a class.
+
+## Extension model (unchanged)
+
+Every new attack fits the existing pattern:
+
+1. Add a config entry to `configs/attacks.yaml` with a `kind`.
+2. If `kind: command`, no new code needed — just command tokens (same as
+   `xmas_flood`/`tcp_syn_flood`/etc using `hping3`/`nmap`).
+3. If the attack needs in-process logic (multicast, raw sockets, custom
+   protocol handling, timing control), add a native executor module under
+   `src/capex/attacks/` implementing `BoundAttackExecutor` (see `hulk.py`
+   for the reference shape), a matching `*AttackConfig` model in
+   `models.py`, and register the `kind` in `registry.py`.
+
+No changes to orchestration (`runner.py`, `scheduler.py`,
+`services/capture_session.py`) are needed for any of the categories below.
+
+## Workflow
+
+- `enhancement/66-expand-attack-library` (off `dev`) is the shared local
+  base each category branches from.
+- Each category gets its own branch and its own PR **straight to `dev`**
+  (not to the umbrella branch) — merged manually by the user, one at a time.
+- After a category's PR merges, its sub-issue is closed with a comment
+  linking the merge commit, same pattern as #70/#74.
+- Categories are tackled roughly in the order listed below, but each is an
+  independently mergeable unit.
+
+## Categories
+
+Each will get its own GitHub sub-issue under #66 with this scope:
+
+1. **Reconnaissance / Discovery** — T1595, T1046. `nmap -sV` service/version
+   detection (`command` kind, same shape as `xmas_flood`). UPnP/SSDP
+   discovery (multicast M-SEARCH) and banner grabbing — new native executor
+   (custom socket/multicast logic).
+2. **Credential Access** — T1110, T1078.001. `hydra`/`medusa` brute force
+   against HTTP basic auth, RTSP, telnet with IoT default-credential
+   wordlists (`command` kind). New `max_attempts`/rate-limit config knob to
+   bound lockout/brick risk even in the sandboxed lab.
+3. **Application-layer** — T1499.002/.004, T1190. Slowloris/`slowhttptest`
+   (`command` kind). Malformed/fuzzed HTTP requests and directory
+   traversal/injection probes against device web UIs — new native executor.
+4. **Lateral Movement / C2** — T1071. Simulated periodic beacon/check-in
+   traffic with jittered intervals, mimicking real botnet C2 check-in
+   patterns — new native executor (`c2_beacon`).
+5. **Exfiltration** — T1041. Simulated bulk outbound transfer / data-staging
+   bursts — new native executor (`exfil_sim`).
+6. **Impact beyond flooding** — T1489, T1565. Simulated firmware/config
+   tampering requests. Requires per-device safety vetting before enabling
+   any specific payload — a bad request could brick real lab hardware
+   regardless of sandboxing; scope narrows per-device as we get there.
+7. **Reflection/Amplification DDoS** — T1498.002. SSDP/DNS/NTP reflection
+   floods bouncing spoofed queries off amplifiers — the actual
+   Mirai/Gafgyt DDoS-for-hire signature, distinct from the existing direct
+   floods.
+8. **ARP Spoofing / MITM** — T1557.002. Real ARP cache poisoning on the lab
+   LAN (`arpspoof`/scapy) — common on-path step in real IoT botnet lateral
+   movement; produces a packet signature nothing else in the set does.
+
+## Testing
+
+Each category PR follows existing repo conventions: unit tests for any new
+executor/model (see `tests/test_hulk.py` and `tests/test_builtins.py` for
+the pattern — construct executor, exercise `execute()`, assert on
+returned detail string / side effects), `ruff` clean, `pytest-cov` gaps
+closed per the repo's existing coverage bar (see #60).

--- a/src/capex/attacks/discovery.py
+++ b/src/capex/attacks/discovery.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import socket
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from capex.models import BannerGrabAttackConfig, DeviceConfig, SsdpDiscoveryAttackConfig
+
+_SSDP_PORT = 1900
+_SSDP_RECV_BUFFER = 4096
+_BANNER_RECV_BUFFER = 1024
+_BANNER_TRUNCATE_LENGTH = 200
+
+
+def _build_msearch(mx_seconds: int) -> bytes:
+    return (
+        'M-SEARCH * HTTP/1.1\r\n'
+        'HOST: 239.255.255.250:1900\r\n'
+        'MAN: "ssdp:discover"\r\n'
+        f'MX: {mx_seconds}\r\n'
+        'ST: ssdp:all\r\n'
+        '\r\n'
+    ).encode()
+
+
+class SsdpDiscoveryExecutor:
+    """Sends a unicast SSDP M-SEARCH probe directly to the target device."""
+
+    def __init__(self, *, attack: SsdpDiscoveryAttackConfig) -> None:
+        self._attack = attack
+
+    def execute(self, *, device: DeviceConfig) -> str | None:
+        message = _build_msearch(self._attack.timeout_seconds)
+        response_count = 0
+
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.settimeout(self._attack.timeout_seconds)
+            sock.sendto(message, (str(device.ip), _SSDP_PORT))
+
+            while True:
+                try:
+                    sock.recvfrom(_SSDP_RECV_BUFFER)
+                except TimeoutError:
+                    break
+                else:
+                    response_count += 1
+
+        return f'responses={response_count}'
+
+
+class BannerGrabExecutor:
+    """Connects to a device port and reports whatever banner it sends back."""
+
+    def __init__(self, *, attack: BannerGrabAttackConfig) -> None:
+        self._attack = attack
+
+    def execute(self, *, device: DeviceConfig) -> str | None:
+        try:
+            sock = socket.create_connection(
+                (str(device.ip), self._attack.port),
+                timeout=self._attack.timeout_seconds,
+            )
+        except OSError:
+            return 'banner=<connection failed>'
+
+        with sock:
+            sock.settimeout(self._attack.timeout_seconds)
+            if self._attack.probe:
+                probe = self._attack.probe.format(target_ip=str(device.ip)).encode()
+                sock.sendall(probe)
+
+            try:
+                data = sock.recv(_BANNER_RECV_BUFFER)
+            except TimeoutError:
+                return 'banner=<no response>'
+
+        banner = data.decode('utf-8', errors='replace').strip()
+        return f'banner={banner[:_BANNER_TRUNCATE_LENGTH]!r}'

--- a/src/capex/attacks/registry.py
+++ b/src/capex/attacks/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
+from capex.attacks.discovery import BannerGrabExecutor, SsdpDiscoveryExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.exceptions import RegistryError
 
@@ -29,6 +30,14 @@ class AttackRegistry:
                 )
             case 'hulk':
                 return HulkAttackExecutor(
+                    attack=attack,
+                )
+            case 'ssdp_discovery':
+                return SsdpDiscoveryExecutor(
+                    attack=attack,
+                )
+            case 'banner_grab':
+                return BannerGrabExecutor(
                     attack=attack,
                 )
             case _:

--- a/src/capex/models.py
+++ b/src/capex/models.py
@@ -48,7 +48,37 @@ class HulkAttackConfig(BaseModel):
     thread_count: PositiveInt = 100
 
 
-AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig
+class SsdpDiscoveryAttackConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    kind: Literal['ssdp_discovery'] = 'ssdp_discovery'
+    name: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    enabled: bool = True
+    repeats: PositiveInt = 3
+    timeout_seconds: PositiveInt = 3
+
+
+class BannerGrabAttackConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    kind: Literal['banner_grab'] = 'banner_grab'
+    name: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    enabled: bool = True
+    repeats: PositiveInt = 3
+    port: PositiveInt = 80
+    timeout_seconds: PositiveInt = 5
+    probe: str = ''
+
+
+AttackConfig = (
+    CommandAttackConfig
+    | PlaceholderAttackConfig
+    | HulkAttackConfig
+    | SsdpDiscoveryAttackConfig
+    | BannerGrabAttackConfig
+)
 
 
 class AttackFile(BaseModel):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from capex.attacks import discovery
+from capex.models import BannerGrabAttackConfig, DeviceConfig, SsdpDiscoveryAttackConfig
+
+
+class _FakeUdpSocket:
+    def __init__(self, responses: list[bytes]) -> None:
+        self._responses = list(responses)
+        self.sent: list[tuple[bytes, tuple[str, int]]] = []
+
+    def settimeout(self, timeout: float) -> None:
+        pass
+
+    def sendto(self, data: bytes, address: tuple[str, int]) -> None:
+        self.sent.append((data, address))
+
+    def recvfrom(self, bufsize: int) -> tuple[bytes, tuple[str, int]]:
+        if not self._responses:
+            raise TimeoutError
+        return self._responses.pop(0), ('192.168.1.1', 1900)
+
+    def __enter__(self) -> _FakeUdpSocket:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        pass
+
+
+def test_ssdp_discovery_executor_counts_responses(monkeypatch) -> None:
+    fake_socket = _FakeUdpSocket(
+        responses=[
+            b'HTTP/1.1 200 OK\r\nSERVER: Linux/1.0 UPnP/1.0\r\n\r\n',
+            b'HTTP/1.1 200 OK\r\nSERVER: Linux/1.0 UPnP/1.0\r\n\r\n',
+        ]
+    )
+    monkeypatch.setattr(discovery.socket, 'socket', lambda *args, **kwargs: fake_socket)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = SsdpDiscoveryAttackConfig(name='ssdp_discovery', label='SSDP_Discovery')
+    executor = discovery.SsdpDiscoveryExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'responses=2'
+    assert fake_socket.sent[0][1] == ('192.168.1.1', 1900)
+
+
+def test_ssdp_discovery_executor_returns_zero_on_no_response(monkeypatch) -> None:
+    fake_socket = _FakeUdpSocket(responses=[])
+    monkeypatch.setattr(discovery.socket, 'socket', lambda *args, **kwargs: fake_socket)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = SsdpDiscoveryAttackConfig(name='ssdp_discovery', label='SSDP_Discovery')
+    executor = discovery.SsdpDiscoveryExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'responses=0'
+
+
+class _FakeTcpSocket:
+    def __init__(self, *, recv_data: bytes = b'', recv_error: Exception | None = None) -> None:
+        self._recv_data = recv_data
+        self._recv_error = recv_error
+        self.sent: bytes = b''
+
+    def settimeout(self, timeout: float) -> None:
+        pass
+
+    def sendall(self, data: bytes) -> None:
+        self.sent = data
+
+    def recv(self, bufsize: int) -> bytes:
+        if self._recv_error is not None:
+            raise self._recv_error
+        return self._recv_data
+
+    def __enter__(self) -> _FakeTcpSocket:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        pass
+
+
+def test_banner_grab_executor_returns_banner_text(monkeypatch) -> None:
+    fake_socket = _FakeTcpSocket(recv_data=b'220 ready\r\n')
+    monkeypatch.setattr(discovery.socket, 'create_connection', lambda address, timeout: fake_socket)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = BannerGrabAttackConfig(name='banner_grab', label='Banner_Grab', port=23)
+    executor = discovery.BannerGrabExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == "banner='220 ready'"
+
+
+def test_banner_grab_executor_sends_configured_probe(monkeypatch) -> None:
+    fake_socket = _FakeTcpSocket(recv_data=b'HTTP/1.1 200 OK\r\n')
+    monkeypatch.setattr(discovery.socket, 'create_connection', lambda address, timeout: fake_socket)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = BannerGrabAttackConfig(
+        name='banner_grab_http',
+        label='Banner_Grab_HTTP',
+        port=80,
+        probe='HEAD / HTTP/1.0\r\nHost: {target_ip}\r\n\r\n',
+    )
+    executor = discovery.BannerGrabExecutor(attack=attack)
+
+    executor.execute(device=device)
+
+    assert fake_socket.sent == b'HEAD / HTTP/1.0\r\nHost: 192.168.1.1\r\n\r\n'
+
+
+def test_banner_grab_executor_handles_connection_refused(monkeypatch) -> None:
+    def refuse(address: tuple[str, int], timeout: float) -> None:
+        raise ConnectionRefusedError
+
+    monkeypatch.setattr(discovery.socket, 'create_connection', refuse)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = BannerGrabAttackConfig(name='banner_grab', label='Banner_Grab', port=23)
+    executor = discovery.BannerGrabExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'banner=<connection failed>'
+
+
+def test_banner_grab_executor_handles_no_response(monkeypatch) -> None:
+    fake_socket = _FakeTcpSocket(recv_error=TimeoutError)
+    monkeypatch.setattr(discovery.socket, 'create_connection', lambda address, timeout: fake_socket)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = BannerGrabAttackConfig(name='banner_grab', label='Banner_Grab', port=23)
+    executor = discovery.BannerGrabExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'banner=<no response>'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from ipaddress import IPv4Address
 
-from capex.models import CommandAttackConfig, DeviceConfig
+from capex.models import BannerGrabAttackConfig, CommandAttackConfig, DeviceConfig, SsdpDiscoveryAttackConfig
 
 
 def test_device_config_validates() -> None:
@@ -17,3 +17,14 @@ def test_attack_config_validates() -> None:
         command=['hping3', '--udp', '-c', '100', '-p', '53', '{target_ip}'],
     )
     assert attack.repeats == 3
+
+
+def test_ssdp_discovery_attack_config_defaults() -> None:
+    attack = SsdpDiscoveryAttackConfig(name='ssdp_discovery', label='SSDP_Discovery')
+    assert attack.timeout_seconds == 3
+
+
+def test_banner_grab_attack_config_defaults() -> None:
+    attack = BannerGrabAttackConfig(name='banner_grab', label='Banner_Grab')
+    assert attack.port == 80
+    assert attack.probe == ''

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,10 +5,17 @@ import types
 import pytest
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
+from capex.attacks.discovery import BannerGrabExecutor, SsdpDiscoveryExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.attacks.registry import AttackRegistry
 from capex.exceptions import RegistryError
-from capex.models import CommandAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
+from capex.models import (
+    BannerGrabAttackConfig,
+    CommandAttackConfig,
+    HulkAttackConfig,
+    PlaceholderAttackConfig,
+    SsdpDiscoveryAttackConfig,
+)
 from capex.runner import CommandRunner
 
 
@@ -45,6 +52,28 @@ def test_registry_resolves_hulk_attack() -> None:
     )
     resolved = registry.resolve(attack)
     assert isinstance(resolved, HulkAttackExecutor)
+
+
+def test_registry_resolves_ssdp_discovery_attack() -> None:
+    registry = AttackRegistry(CommandRunner())
+    attack = SsdpDiscoveryAttackConfig(
+        name='ssdp_discovery',
+        label='SSDP_Discovery',
+        kind='ssdp_discovery',
+    )
+    resolved = registry.resolve(attack)
+    assert isinstance(resolved, SsdpDiscoveryExecutor)
+
+
+def test_registry_resolves_banner_grab_attack() -> None:
+    registry = AttackRegistry(CommandRunner())
+    attack = BannerGrabAttackConfig(
+        name='banner_grab',
+        label='Banner_Grab',
+        kind='banner_grab',
+    )
+    resolved = registry.resolve(attack)
+    assert isinstance(resolved, BannerGrabExecutor)
 
 
 def test_registry_raises_registry_error_for_unsupported_kind() -> None:


### PR DESCRIPTION
Part of the attack-library expansion roadmap in #66. Resolves #75.

## Summary
- `nmap -sV` service/version detection added to `attacks.yaml` (`kind: command`, no new code — same shape as existing `xmas_flood`).
- New native executor `SsdpDiscoveryExecutor` (`kind: ssdp_discovery`): sends a unicast SSDP M-SEARCH probe directly to the target device and counts responses.
- New native executor `BannerGrabExecutor` (`kind: banner_grab`): connects to a configurable port, optionally sends a configured probe (e.g. an HTTP HEAD), and reports whatever banner comes back.
- Both new kinds wired into `AttackRegistry` and the `AttackConfig` union in `models.py`.
- README's attack-kind list updated to document the two new kinds.

MITRE: T1595 Active Scanning, T1046 Network Service Scanning.

Real tools/traffic only — real `nmap`, real SSDP protocol messages, real TCP banners from real lab devices — per #66's authenticity requirement.

## Test plan
- [x] `uv run pytest` — full suite green (74 tests)
- [x] `uv run pytest --cov=capex` — `discovery.py` and `registry.py` both 100%
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run capex --dry-run` — confirms `configs/attacks.yaml` loads/validates with the 3 new attack entries

I'll merge this manually; will close #75 with a comment linking the merge afterward.