### PR TITLE
feat: credential access attack via real hydra brute force

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Each attack is defined by a `kind` field and mapped to an executor:
 
 * `command` executes external binaries such as `nmap` or `hping3`
 * `hulk` runs an in-process HTTP flood (HULK) against the target device; configurable via `duration_seconds` and `thread_count`
+* `hydra_brute_force` runs real `hydra` against a device using a combo file built (and capped) from `username_list`/`password_list`/`max_attempts`, so the attempt cap is enforced in code rather than trusted to CLI flags
 * `placeholder` is a disabled stub for attacks not yet implemented (cannot be `enabled: true`)
 * additional attack types can be added via the registry
 

--- a/configs/attacks.yaml
+++ b/configs/attacks.yaml
@@ -57,6 +57,24 @@ attacks:
     repeats: 3
     duration_seconds: 60
 
+  # Credential Access (#76)
+  - name: hydra_http_default_creds
+    label: Hydra_HTTP_Default_Creds
+    kind: hydra_brute_force
+    enabled: true
+    repeats: 3
+    service: http-get
+    port: 80
+    username_list:
+      - admin
+      - root
+    password_list:
+      - admin
+      - "1234"
+      - password
+    max_attempts: 6
+    tasks: 1
+
   # - name: http_request
   #   label: HTTP_Request
   #   enabled: false

--- a/src/capex/attacks/credential_access.py
+++ b/src/capex/attacks/credential_access.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import itertools
+import tempfile
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from capex.models import DeviceConfig, HydraBruteForceAttackConfig
+    from capex.runner import CommandRunner
+
+
+class HydraBruteForceExecutor:
+    """Runs real hydra against a device using a combo file capped at max_attempts.
+
+    The credential-pair list is truncated in code before hydra ever runs, so
+    the attempt cap holds regardless of how hydra's own flags are configured
+    - this bounds lockout/bricking risk against real lab hardware.
+    """
+
+    def __init__(self, *, runner: CommandRunner, attack: HydraBruteForceAttackConfig) -> None:
+        self._runner = runner
+        self._attack = attack
+
+    def execute(self, *, device: DeviceConfig) -> str | None:
+        pairs = list(
+            itertools.islice(
+                itertools.product(self._attack.username_list, self._attack.password_list),
+                self._attack.max_attempts,
+            )
+        )
+        combo_text = ''.join(f'{user}:{password}\n' for user, password in pairs)
+
+        with tempfile.NamedTemporaryFile('w', suffix='.txt', delete=False) as handle:
+            handle.write(combo_text)
+            combo_path = Path(handle.name)
+
+        try:
+            self._runner.run(
+                [
+                    self._attack.hydra_binary,
+                    '-C',
+                    str(combo_path),
+                    '-t',
+                    str(self._attack.tasks),
+                    str(device.ip),
+                    self._attack.service,
+                    '-s',
+                    str(self._attack.port),
+                ],
+                check=False,
+            )
+        finally:
+            combo_path.unlink(missing_ok=True)
+
+        return f'attempts={len(pairs)}'

--- a/src/capex/attacks/registry.py
+++ b/src/capex/attacks/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
+from capex.attacks.credential_access import HydraBruteForceExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.exceptions import RegistryError
 
@@ -29,6 +30,11 @@ class AttackRegistry:
                 )
             case 'hulk':
                 return HulkAttackExecutor(
+                    attack=attack,
+                )
+            case 'hydra_brute_force':
+                return HydraBruteForceExecutor(
+                    runner=self._runner,
                     attack=attack,
                 )
             case _:

--- a/src/capex/models.py
+++ b/src/capex/models.py
@@ -48,7 +48,24 @@ class HulkAttackConfig(BaseModel):
     thread_count: PositiveInt = 100
 
 
-AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig
+class HydraBruteForceAttackConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    kind: Literal['hydra_brute_force'] = 'hydra_brute_force'
+    name: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    enabled: bool = True
+    repeats: PositiveInt = 3
+    service: str = Field(min_length=1)
+    port: PositiveInt
+    username_list: list[str] = Field(min_length=1)
+    password_list: list[str] = Field(min_length=1)
+    max_attempts: PositiveInt = 10
+    tasks: PositiveInt = 1
+    hydra_binary: str = 'hydra'
+
+
+AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig | HydraBruteForceAttackConfig
 
 
 class AttackFile(BaseModel):

--- a/tests/test_credential_access.py
+++ b/tests/test_credential_access.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from capex.attacks import credential_access
+from capex.models import DeviceConfig, HydraBruteForceAttackConfig
+from capex.runner import CompletedCommand
+
+
+class _FakeRunner:
+    def __init__(self, *, returncode: int = 1) -> None:
+        self.calls: list[list[str]] = []
+        self.combo_file_content: str | None = None
+        self.combo_file_path: Path | None = None
+        self._returncode = returncode
+
+    def run(self, args, *, check: bool = True, cwd=None) -> CompletedCommand:
+        self.calls.append(list(args))
+        combo_path = Path(args[args.index('-C') + 1])
+        self.combo_file_path = combo_path
+        self.combo_file_content = combo_path.read_text()
+        return CompletedCommand(args=tuple(args), returncode=self._returncode, stdout='', stderr='')
+
+
+def test_hydra_executor_caps_attempts_to_max_attempts() -> None:
+    runner = _FakeRunner()
+    attack = HydraBruteForceAttackConfig(
+        name='hydra_http_default_creds',
+        label='Hydra_HTTP_Default_Creds',
+        service='http-get',
+        port=80,
+        username_list=['admin', 'root'],
+        password_list=['admin', '1234'],
+        max_attempts=3,
+    )
+    executor = credential_access.HydraBruteForceExecutor(runner=runner, attack=attack)
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'attempts=3'
+    assert runner.combo_file_content == 'admin:admin\nadmin:1234\nroot:admin\n'
+
+
+def test_hydra_executor_invokes_hydra_with_expected_args() -> None:
+    runner = _FakeRunner()
+    attack = HydraBruteForceAttackConfig(
+        name='hydra_http_default_creds',
+        label='Hydra_HTTP_Default_Creds',
+        service='http-get',
+        port=8080,
+        username_list=['admin'],
+        password_list=['admin'],
+        tasks=1,
+    )
+    executor = credential_access.HydraBruteForceExecutor(runner=runner, attack=attack)
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+
+    executor.execute(device=device)
+
+    call = runner.calls[0]
+    assert call[0] == 'hydra'
+    assert '-t' in call
+    assert call[call.index('-t') + 1] == '1'
+    assert '192.168.1.1' in call
+    assert 'http-get' in call
+    assert '-s' in call
+    assert call[call.index('-s') + 1] == '8080'
+
+
+def test_hydra_executor_cleans_up_combo_file_after_run() -> None:
+    runner = _FakeRunner()
+    attack = HydraBruteForceAttackConfig(
+        name='hydra_http_default_creds',
+        label='Hydra_HTTP_Default_Creds',
+        service='http-get',
+        port=80,
+        username_list=['admin'],
+        password_list=['admin'],
+    )
+    executor = credential_access.HydraBruteForceExecutor(runner=runner, attack=attack)
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+
+    executor.execute(device=device)
+
+    assert runner.combo_file_path is not None
+    assert not runner.combo_file_path.exists()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from ipaddress import IPv4Address
 
-from capex.models import CommandAttackConfig, DeviceConfig
+from capex.models import CommandAttackConfig, DeviceConfig, HydraBruteForceAttackConfig
 
 
 def test_device_config_validates() -> None:
@@ -17,3 +17,16 @@ def test_attack_config_validates() -> None:
         command=['hping3', '--udp', '-c', '100', '-p', '53', '{target_ip}'],
     )
     assert attack.repeats == 3
+
+
+def test_hydra_brute_force_attack_config_defaults() -> None:
+    attack = HydraBruteForceAttackConfig(
+        name='hydra_http_default_creds',
+        label='Hydra_HTTP_Default_Creds',
+        service='http-get',
+        port=80,
+        username_list=['admin'],
+        password_list=['admin'],
+    )
+    assert attack.max_attempts == 10
+    assert attack.tasks == 1

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,10 +5,16 @@ import types
 import pytest
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
+from capex.attacks.credential_access import HydraBruteForceExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.attacks.registry import AttackRegistry
 from capex.exceptions import RegistryError
-from capex.models import CommandAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
+from capex.models import (
+    CommandAttackConfig,
+    HulkAttackConfig,
+    HydraBruteForceAttackConfig,
+    PlaceholderAttackConfig,
+)
 from capex.runner import CommandRunner
 
 
@@ -45,6 +51,20 @@ def test_registry_resolves_hulk_attack() -> None:
     )
     resolved = registry.resolve(attack)
     assert isinstance(resolved, HulkAttackExecutor)
+
+
+def test_registry_resolves_hydra_brute_force_attack() -> None:
+    registry = AttackRegistry(CommandRunner())
+    attack = HydraBruteForceAttackConfig(
+        name='hydra_http_default_creds',
+        label='Hydra_HTTP_Default_Creds',
+        service='http-get',
+        port=80,
+        username_list=['admin'],
+        password_list=['admin'],
+    )
+    resolved = registry.resolve(attack)
+    assert isinstance(resolved, HydraBruteForceExecutor)
 
 
 def test_registry_raises_registry_error_for_unsupported_kind() -> None:


### PR DESCRIPTION
Part of the attack-library expansion roadmap in #66. Resolves #76.

## Summary
- New native executor `HydraBruteForceExecutor` (`kind: hydra_brute_force`) shells out to real `hydra` against a device using `-C` combo-file mode.
- `username_list` × `password_list` are combined and truncated to `max_attempts` **in code** before the combo file is written, so the attempt cap holds regardless of hydra's own flags — bounds lockout/brick risk against real lab hardware.
- Combo file is a temp file, cleaned up after each run.
- New `hydra_http_default_creds` entry in `attacks.yaml` (`service: http-get`, small IoT default-credential list, `max_attempts: 6`, `tasks: 1` to stay slow/non-hammering).
- Registered in `AttackRegistry`, added to the `AttackConfig` union, documented in README.

MITRE: T1110 Brute Force, T1078.001 Default Accounts.

Real tool, real traffic — actual `hydra` against real lab devices, per #66's authenticity requirement.

## Test plan
- [x] `uv run pytest` — full suite green (77 tests)
- [x] `uv run pytest --cov=capex` — `credential_access.py` and `registry.py` both 100%
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run capex --dry-run` — confirms `configs/attacks.yaml` loads/validates with the new attack entry

I'll merge this manually; will close #76 with a comment linking the merge afterward.