### PR TITLE
feat: C2 beacon simulation attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Each attack is defined by a `kind` field and mapped to an executor:
 
 * `command` executes external binaries such as `nmap` or `hping3`
 * `hulk` runs an in-process HTTP flood (HULK) against the target device; configurable via `duration_seconds` and `thread_count`
+* `c2_beacon` sends a single jittered check-in request per invocation, mimicking botnet C2 callback traffic; configurable via `port`, `path`, and `jitter_seconds`
 * `placeholder` is a disabled stub for attacks not yet implemented (cannot be `enabled: true`)
 * additional attack types can be added via the registry
 

--- a/configs/attacks.yaml
+++ b/configs/attacks.yaml
@@ -57,6 +57,17 @@ attacks:
     repeats: 3
     duration_seconds: 60
 
+  # Lateral Movement / C2 (#78)
+  - name: c2_beacon
+    label: C2_Beacon
+    kind: c2_beacon
+    enabled: true
+    repeats: 5
+    port: 80
+    path: /check-in
+    jitter_seconds: 5
+    timeout_seconds: 5
+
   # - name: http_request
   #   label: HTTP_Request
   #   enabled: false

--- a/src/capex/attacks/c2.py
+++ b/src/capex/attacks/c2.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import random
+import socket
+import time
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from capex.models import C2BeaconAttackConfig, DeviceConfig
+
+_BEACON_USER_AGENT = 'capex-c2-sim/1.0'
+_RECV_BUFFER = 1024
+
+
+class C2BeaconExecutor:
+    """Sends a single jittered check-in request, mimicking botnet C2 beaconing.
+
+    Each invocation sends one beacon; repeats/scheduling spread beacons
+    across the capture window to produce a periodic-with-jitter traffic
+    pattern representing post-compromise callback behavior.
+    """
+
+    def __init__(self, *, attack: C2BeaconAttackConfig) -> None:
+        self._attack = attack
+
+    def execute(self, *, device: DeviceConfig) -> str | None:
+        if self._attack.jitter_seconds:
+            time.sleep(random.uniform(0, self._attack.jitter_seconds))
+
+        host = str(device.ip)
+        request = (
+            f'GET {self._attack.path} HTTP/1.1\r\n'
+            f'Host: {host}\r\n'
+            f'User-Agent: {_BEACON_USER_AGENT}\r\n'
+            'Connection: close\r\n\r\n'
+        ).encode()
+
+        try:
+            sock = socket.create_connection((host, self._attack.port), timeout=self._attack.timeout_seconds)
+        except OSError:
+            return 'beacon=<unreachable>'
+
+        with sock:
+            sock.settimeout(self._attack.timeout_seconds)
+            sock.sendall(request)
+            try:
+                sock.recv(_RECV_BUFFER)
+            except TimeoutError:
+                pass
+
+        return 'beacon=sent'

--- a/src/capex/attacks/registry.py
+++ b/src/capex/attacks/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
+from capex.attacks.c2 import C2BeaconExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.exceptions import RegistryError
 
@@ -29,6 +30,10 @@ class AttackRegistry:
                 )
             case 'hulk':
                 return HulkAttackExecutor(
+                    attack=attack,
+                )
+            case 'c2_beacon':
+                return C2BeaconExecutor(
                     attack=attack,
                 )
             case _:

--- a/src/capex/models.py
+++ b/src/capex/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, IPvAnyAddress, PositiveInt
+from pydantic import BaseModel, ConfigDict, Field, IPvAnyAddress, NonNegativeInt, PositiveInt
 
 
 class DeviceConfig(BaseModel):
@@ -48,7 +48,21 @@ class HulkAttackConfig(BaseModel):
     thread_count: PositiveInt = 100
 
 
-AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig
+class C2BeaconAttackConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    kind: Literal['c2_beacon'] = 'c2_beacon'
+    name: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    enabled: bool = True
+    repeats: PositiveInt = 3
+    port: PositiveInt = 80
+    path: str = '/'
+    jitter_seconds: NonNegativeInt = 5
+    timeout_seconds: PositiveInt = 5
+
+
+AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig | C2BeaconAttackConfig
 
 
 class AttackFile(BaseModel):

--- a/tests/test_c2.py
+++ b/tests/test_c2.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from capex.attacks import c2
+from capex.models import C2BeaconAttackConfig, DeviceConfig
+
+
+class _FakeTcpSocket:
+    def __init__(self) -> None:
+        self.sent: bytes = b''
+
+    def settimeout(self, timeout: float) -> None:
+        pass
+
+    def sendall(self, data: bytes) -> None:
+        self.sent = data
+
+    def recv(self, bufsize: int) -> bytes:
+        return b'HTTP/1.1 200 OK\r\n'
+
+    def __enter__(self) -> _FakeTcpSocket:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        pass
+
+
+def test_c2_beacon_executor_sends_beacon_request(monkeypatch) -> None:
+    fake_socket = _FakeTcpSocket()
+    addresses: list[tuple[str, int]] = []
+
+    def fake_create_connection(address, timeout):
+        addresses.append(address)
+        return fake_socket
+
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(c2.socket, 'create_connection', fake_create_connection)
+    monkeypatch.setattr(c2.random, 'uniform', lambda a, b: 1.5)
+    monkeypatch.setattr(c2.time, 'sleep', lambda seconds: sleep_calls.append(seconds))
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = C2BeaconAttackConfig(name='c2_beacon', label='C2_Beacon', port=8080, path='/check-in', jitter_seconds=5)
+    executor = c2.C2BeaconExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'beacon=sent'
+    assert addresses == [('192.168.1.1', 8080)]
+    assert sleep_calls == [1.5]
+    assert (
+        fake_socket.sent
+        == b'GET /check-in HTTP/1.1\r\nHost: 192.168.1.1\r\nUser-Agent: capex-c2-sim/1.0\r\nConnection: close\r\n\r\n'
+    )
+
+
+def test_c2_beacon_executor_skips_sleep_when_jitter_is_zero(monkeypatch) -> None:
+    fake_socket = _FakeTcpSocket()
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(c2.socket, 'create_connection', lambda address, timeout: fake_socket)
+    monkeypatch.setattr(c2.time, 'sleep', lambda seconds: sleep_calls.append(seconds))
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = C2BeaconAttackConfig(name='c2_beacon', label='C2_Beacon', jitter_seconds=0)
+    executor = c2.C2BeaconExecutor(attack=attack)
+
+    executor.execute(device=device)
+
+    assert sleep_calls == []
+
+
+def test_c2_beacon_executor_ignores_recv_timeout_after_send(monkeypatch) -> None:
+    class _TimingOutSocket(_FakeTcpSocket):
+        def recv(self, bufsize: int) -> bytes:
+            raise TimeoutError
+
+    fake_socket = _TimingOutSocket()
+    monkeypatch.setattr(c2.socket, 'create_connection', lambda address, timeout: fake_socket)
+    monkeypatch.setattr(c2.time, 'sleep', lambda seconds: None)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = C2BeaconAttackConfig(name='c2_beacon', label='C2_Beacon', jitter_seconds=0)
+    executor = c2.C2BeaconExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'beacon=sent'
+
+
+def test_c2_beacon_executor_returns_unreachable_on_connection_failure(monkeypatch) -> None:
+    def refuse(address, timeout):
+        raise ConnectionRefusedError
+
+    monkeypatch.setattr(c2.socket, 'create_connection', refuse)
+    monkeypatch.setattr(c2.time, 'sleep', lambda seconds: None)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = C2BeaconAttackConfig(name='c2_beacon', label='C2_Beacon', jitter_seconds=0)
+    executor = c2.C2BeaconExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'beacon=<unreachable>'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from ipaddress import IPv4Address
 
-from capex.models import CommandAttackConfig, DeviceConfig
+from capex.models import C2BeaconAttackConfig, CommandAttackConfig, DeviceConfig
 
 
 def test_device_config_validates() -> None:
@@ -17,3 +17,9 @@ def test_attack_config_validates() -> None:
         command=['hping3', '--udp', '-c', '100', '-p', '53', '{target_ip}'],
     )
     assert attack.repeats == 3
+
+
+def test_c2_beacon_attack_config_defaults() -> None:
+    attack = C2BeaconAttackConfig(name='c2_beacon', label='C2_Beacon')
+    assert attack.jitter_seconds == 5
+    assert attack.path == '/'

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,10 +5,11 @@ import types
 import pytest
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
+from capex.attacks.c2 import C2BeaconExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.attacks.registry import AttackRegistry
 from capex.exceptions import RegistryError
-from capex.models import CommandAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
+from capex.models import C2BeaconAttackConfig, CommandAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
 from capex.runner import CommandRunner
 
 
@@ -45,6 +46,13 @@ def test_registry_resolves_hulk_attack() -> None:
     )
     resolved = registry.resolve(attack)
     assert isinstance(resolved, HulkAttackExecutor)
+
+
+def test_registry_resolves_c2_beacon_attack() -> None:
+    registry = AttackRegistry(CommandRunner())
+    attack = C2BeaconAttackConfig(name='c2_beacon', label='C2_Beacon')
+    resolved = registry.resolve(attack)
+    assert isinstance(resolved, C2BeaconExecutor)
 
 
 def test_registry_raises_registry_error_for_unsupported_kind() -> None:


### PR DESCRIPTION
Part of the attack-library expansion roadmap in #66. Resolves #78.

## Summary
- New native executor `C2BeaconExecutor` (`kind: c2_beacon`): sends one jittered check-in request per invocation (`GET {path}` with a distinct `capex-c2-sim/1.0` user-agent). Repeats/scheduling already spread individual invocations across the capture window, so the result is a periodic-with-jitter traffic pattern representing post-compromise C2 callback behavior — distinct from the active-attack traffic elsewhere in the set.
- `jitter_seconds` (default 5, can be 0 to disable) controls a pre-send random delay via `random.uniform`.
- New `c2_beacon` entry in `attacks.yaml` with `repeats: 5` so beaconing is visibly periodic across the run.
- Registered in `AttackRegistry`, added to the `AttackConfig` union, documented in README.

MITRE: T1071 Application Layer Protocol (C2).

## Test plan
- [x] `uv run pytest` — full suite green (84 tests)
- [x] `uv run pytest --cov=capex` — `c2.py` and `registry.py` both 100%
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run capex --dry-run` — confirms `configs/attacks.yaml` loads/validates with the new entry

I'll merge this manually; will close #78 with a comment linking the merge afterward.