### PR TITLE
feat: exfiltration bulk-transfer simulation attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Each attack is defined by a `kind` field and mapped to an executor:
 
 * `command` executes external binaries such as `nmap` or `hping3`
 * `hulk` runs an in-process HTTP flood (HULK) against the target device; configurable via `duration_seconds` and `thread_count`
+* `exfil_sim` sends a bulk outbound POST burst simulating data-staging/exfil traffic; configurable via `payload_size_bytes` and `chunk_size_bytes`
 * `placeholder` is a disabled stub for attacks not yet implemented (cannot be `enabled: true`)
 * additional attack types can be added via the registry
 

--- a/configs/attacks.yaml
+++ b/configs/attacks.yaml
@@ -57,6 +57,18 @@ attacks:
     repeats: 3
     duration_seconds: 60
 
+  # Exfiltration (#79)
+  - name: exfil_sim
+    label: Exfil_Sim
+    kind: exfil_sim
+    enabled: true
+    repeats: 3
+    port: 80
+    path: /upload
+    payload_size_bytes: 2000000
+    chunk_size_bytes: 65536
+    timeout_seconds: 10
+
   # - name: http_request
   #   label: HTTP_Request
   #   enabled: false

--- a/src/capex/attacks/exfil.py
+++ b/src/capex/attacks/exfil.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+import socket
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from capex.models import DeviceConfig, ExfilSimAttackConfig
+
+_RECV_BUFFER = 1024
+
+
+class ExfilSimExecutor:
+    """Sends a bulk outbound POST burst, simulating data-staging/exfil traffic."""
+
+    def __init__(self, *, attack: ExfilSimAttackConfig) -> None:
+        self._attack = attack
+
+    def execute(self, *, device: DeviceConfig) -> str | None:
+        host = str(device.ip)
+        header = (
+            f'POST {self._attack.path} HTTP/1.1\r\n'
+            f'Host: {host}\r\n'
+            'Content-Type: application/octet-stream\r\n'
+            f'Content-Length: {self._attack.payload_size_bytes}\r\n'
+            'Connection: close\r\n\r\n'
+        ).encode()
+
+        try:
+            sock = socket.create_connection((host, self._attack.port), timeout=self._attack.timeout_seconds)
+        except OSError:
+            return 'bytes_sent=0'
+
+        bytes_sent = 0
+        with sock:
+            sock.settimeout(self._attack.timeout_seconds)
+            try:
+                sock.sendall(header)
+
+                remaining = self._attack.payload_size_bytes
+                while remaining > 0:
+                    chunk_len = min(self._attack.chunk_size_bytes, remaining)
+                    sock.sendall(os.urandom(chunk_len))
+                    bytes_sent += chunk_len
+                    remaining -= chunk_len
+            except OSError:
+                pass
+            else:
+                try:
+                    sock.recv(_RECV_BUFFER)
+                except TimeoutError:
+                    pass
+
+        return f'bytes_sent={bytes_sent}'

--- a/src/capex/attacks/registry.py
+++ b/src/capex/attacks/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
+from capex.attacks.exfil import ExfilSimExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.exceptions import RegistryError
 
@@ -29,6 +30,10 @@ class AttackRegistry:
                 )
             case 'hulk':
                 return HulkAttackExecutor(
+                    attack=attack,
+                )
+            case 'exfil_sim':
+                return ExfilSimExecutor(
                     attack=attack,
                 )
             case _:

--- a/src/capex/models.py
+++ b/src/capex/models.py
@@ -48,7 +48,22 @@ class HulkAttackConfig(BaseModel):
     thread_count: PositiveInt = 100
 
 
-AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig
+class ExfilSimAttackConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    kind: Literal['exfil_sim'] = 'exfil_sim'
+    name: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    enabled: bool = True
+    repeats: PositiveInt = 3
+    port: PositiveInt = 80
+    path: str = '/upload'
+    payload_size_bytes: PositiveInt = 1_000_000
+    chunk_size_bytes: PositiveInt = 65_536
+    timeout_seconds: PositiveInt = 10
+
+
+AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig | ExfilSimAttackConfig
 
 
 class AttackFile(BaseModel):

--- a/tests/test_exfil.py
+++ b/tests/test_exfil.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from capex.attacks import exfil
+from capex.models import DeviceConfig, ExfilSimAttackConfig
+
+
+class _FakeTcpSocket:
+    def __init__(self, *, fail_after_chunks: int | None = None) -> None:
+        self.sent_chunks: list[bytes] = []
+        self._fail_after_chunks = fail_after_chunks
+
+    def settimeout(self, timeout: float) -> None:
+        pass
+
+    def sendall(self, data: bytes) -> None:
+        if self._fail_after_chunks is not None and len(self.sent_chunks) >= self._fail_after_chunks:
+            raise ConnectionResetError
+        self.sent_chunks.append(data)
+
+    def recv(self, bufsize: int) -> bytes:
+        return b'HTTP/1.1 200 OK\r\n'
+
+    def __enter__(self) -> _FakeTcpSocket:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        pass
+
+
+def test_exfil_executor_sends_header_then_chunks_totaling_payload_size(monkeypatch) -> None:
+    fake_socket = _FakeTcpSocket()
+    monkeypatch.setattr(exfil.socket, 'create_connection', lambda address, timeout: fake_socket)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = ExfilSimAttackConfig(
+        name='exfil_sim',
+        label='Exfil_Sim',
+        port=8080,
+        path='/upload',
+        payload_size_bytes=150_000,
+        chunk_size_bytes=65_536,
+    )
+    executor = exfil.ExfilSimExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'bytes_sent=150000'
+    header = fake_socket.sent_chunks[0]
+    assert header == (
+        b'POST /upload HTTP/1.1\r\n'
+        b'Host: 192.168.1.1\r\n'
+        b'Content-Type: application/octet-stream\r\n'
+        b'Content-Length: 150000\r\n'
+        b'Connection: close\r\n\r\n'
+    )
+    body_chunks = fake_socket.sent_chunks[1:]
+    assert [len(chunk) for chunk in body_chunks] == [65536, 65536, 18928]
+    assert sum(len(chunk) for chunk in body_chunks) == 150_000
+
+
+def test_exfil_executor_ignores_recv_timeout_after_full_send(monkeypatch) -> None:
+    class _TimingOutSocket(_FakeTcpSocket):
+        def recv(self, bufsize: int) -> bytes:
+            raise TimeoutError
+
+    fake_socket = _TimingOutSocket()
+    monkeypatch.setattr(exfil.socket, 'create_connection', lambda address, timeout: fake_socket)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = ExfilSimAttackConfig(name='exfil_sim', label='Exfil_Sim', payload_size_bytes=1000)
+    executor = exfil.ExfilSimExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'bytes_sent=1000'
+
+
+def test_exfil_executor_returns_zero_on_connection_failure(monkeypatch) -> None:
+    def refuse(address, timeout):
+        raise ConnectionRefusedError
+
+    monkeypatch.setattr(exfil.socket, 'create_connection', refuse)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = ExfilSimAttackConfig(name='exfil_sim', label='Exfil_Sim', port=80, payload_size_bytes=1000)
+    executor = exfil.ExfilSimExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'bytes_sent=0'
+
+
+def test_exfil_executor_reports_partial_bytes_sent_on_mid_stream_failure(monkeypatch) -> None:
+    fake_socket = _FakeTcpSocket(fail_after_chunks=2)
+    monkeypatch.setattr(exfil.socket, 'create_connection', lambda address, timeout: fake_socket)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = ExfilSimAttackConfig(
+        name='exfil_sim',
+        label='Exfil_Sim',
+        port=80,
+        payload_size_bytes=150_000,
+        chunk_size_bytes=65_536,
+    )
+    executor = exfil.ExfilSimExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'bytes_sent=65536'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from ipaddress import IPv4Address
 
-from capex.models import CommandAttackConfig, DeviceConfig
+from capex.models import CommandAttackConfig, DeviceConfig, ExfilSimAttackConfig
 
 
 def test_device_config_validates() -> None:
@@ -17,3 +17,9 @@ def test_attack_config_validates() -> None:
         command=['hping3', '--udp', '-c', '100', '-p', '53', '{target_ip}'],
     )
     assert attack.repeats == 3
+
+
+def test_exfil_sim_attack_config_defaults() -> None:
+    attack = ExfilSimAttackConfig(name='exfil_sim', label='Exfil_Sim')
+    assert attack.payload_size_bytes == 1_000_000
+    assert attack.chunk_size_bytes == 65_536

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,10 +5,11 @@ import types
 import pytest
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
+from capex.attacks.exfil import ExfilSimExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.attacks.registry import AttackRegistry
 from capex.exceptions import RegistryError
-from capex.models import CommandAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
+from capex.models import CommandAttackConfig, ExfilSimAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
 from capex.runner import CommandRunner
 
 
@@ -45,6 +46,13 @@ def test_registry_resolves_hulk_attack() -> None:
     )
     resolved = registry.resolve(attack)
     assert isinstance(resolved, HulkAttackExecutor)
+
+
+def test_registry_resolves_exfil_sim_attack() -> None:
+    registry = AttackRegistry(CommandRunner())
+    attack = ExfilSimAttackConfig(name='exfil_sim', label='Exfil_Sim')
+    resolved = registry.resolve(attack)
+    assert isinstance(resolved, ExfilSimExecutor)
 
 
 def test_registry_raises_registry_error_for_unsupported_kind() -> None:


### PR DESCRIPTION
Part of the attack-library expansion roadmap in #66. Resolves #79.

## Summary
- New native executor `ExfilSimExecutor` (`kind: exfil_sim`): sends a real bulk outbound `POST` burst (random bytes, chunked at `chunk_size_bytes`, totaling `payload_size_bytes`) to a device, simulating data-staging/exfil traffic as its own labeled class — distinct in volume/shape from every other attack in the set.
- Mid-stream send failures are caught and `bytes_sent` reports only what was actually confirmed sent.
- New `exfil_sim` entry in `attacks.yaml` (2MB payload, 64KB chunks).
- Registered in `AttackRegistry`, added to the `AttackConfig` union, documented in README.

MITRE: T1041 Exfiltration Over C2 Channel.

## Test plan
- [x] `uv run pytest` — full suite green (88 tests)
- [x] `uv run pytest --cov=capex` — `exfil.py` and `registry.py` both 100%
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run capex --dry-run` — confirms `configs/attacks.yaml` loads/validates with the new entry

I'll merge this manually; will close #79 with a comment linking the merge afterward.