### PR TITLE
feat: config-tampering impact attack (default-disabled)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Each attack is defined by a `kind` field and mapped to an executor:
 
 * `command` executes external binaries such as `nmap` or `hping3`
 * `hulk` runs an in-process HTTP flood (HULK) against the target device; configurable via `duration_seconds` and `thread_count`
+* `config_tamper` sends a real config/firmware-tampering-shaped HTTP request (`path`, `method`, `body`) and reports the response status; defaults to `enabled: false` at the model level - each entry needs per-device safety vetting before it's turned on, since a payload that succeeds could brick real hardware
 * `placeholder` is a disabled stub for attacks not yet implemented (cannot be `enabled: true`)
 * additional attack types can be added via the registry
 

--- a/configs/attacks.yaml
+++ b/configs/attacks.yaml
@@ -57,6 +57,24 @@ attacks:
     repeats: 3
     duration_seconds: 60
 
+  # Impact beyond flooding (#80)
+  # Left disabled by default (and the config_tamper kind itself defaults to
+  # enabled: false at the model level) - the request below is real and
+  # protocol-correct, but whether it actually changes anything depends on
+  # each specific device's firmware. Do not flip enabled: true without
+  # vetting this exact path/body against the specific device it will run
+  # against; a payload that succeeds could brick real lab hardware.
+  - name: config_tamper_setup_cgi
+    label: Config_Tamper_Setup_CGI
+    kind: config_tamper
+    enabled: false
+    repeats: 1
+    port: 80
+    path: /setup.cgi
+    method: POST
+    body: "ssid=capex-test&wpa_psk=capex-test-tamper"
+    timeout_seconds: 5
+
   # - name: http_request
   #   label: HTTP_Request
   #   enabled: false

--- a/src/capex/attacks/impact.py
+++ b/src/capex/attacks/impact.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import socket
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from capex.models import ConfigTamperAttackConfig, DeviceConfig
+
+_RECV_BUFFER = 1024
+
+
+class ConfigTamperExecutor:
+    """Sends a real config/firmware-tampering-shaped request and reports the response status.
+
+    Defaults to enabled: false at the model level - each entry needs
+    per-device safety vetting before it is turned on, since a payload
+    that actually succeeds could brick real lab hardware (see #80).
+    """
+
+    def __init__(self, *, attack: ConfigTamperAttackConfig) -> None:
+        self._attack = attack
+
+    def execute(self, *, device: DeviceConfig) -> str | None:
+        host = str(device.ip)
+        body = self._attack.body.format(target_ip=host).encode()
+        request = (
+            f'{self._attack.method} {self._attack.path} HTTP/1.1\r\n'
+            f'Host: {host}\r\n'
+            'Content-Type: application/x-www-form-urlencoded\r\n'
+            f'Content-Length: {len(body)}\r\n'
+            'Connection: close\r\n\r\n'
+        ).encode() + body
+
+        try:
+            sock = socket.create_connection((host, self._attack.port), timeout=self._attack.timeout_seconds)
+        except OSError:
+            return 'response=<unreachable>'
+
+        with sock:
+            sock.settimeout(self._attack.timeout_seconds)
+            sock.sendall(request)
+            try:
+                data = sock.recv(_RECV_BUFFER)
+            except TimeoutError:
+                return 'response=<no response>'
+
+        status_line = data.split(b'\r\n', 1)[0].decode('utf-8', errors='replace').strip()
+        return f'response={status_line!r}'

--- a/src/capex/attacks/registry.py
+++ b/src/capex/attacks/registry.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
 from capex.attacks.hulk import HulkAttackExecutor
+from capex.attacks.impact import ConfigTamperExecutor
 from capex.exceptions import RegistryError
 
 if TYPE_CHECKING:
@@ -29,6 +30,10 @@ class AttackRegistry:
                 )
             case 'hulk':
                 return HulkAttackExecutor(
+                    attack=attack,
+                )
+            case 'config_tamper':
+                return ConfigTamperExecutor(
                     attack=attack,
                 )
             case _:

--- a/src/capex/models.py
+++ b/src/capex/models.py
@@ -48,7 +48,22 @@ class HulkAttackConfig(BaseModel):
     thread_count: PositiveInt = 100
 
 
-AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig
+class ConfigTamperAttackConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    kind: Literal['config_tamper'] = 'config_tamper'
+    name: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    enabled: bool = False
+    repeats: PositiveInt = 3
+    port: PositiveInt = 80
+    path: str = Field(min_length=1)
+    method: str = 'POST'
+    body: str = Field(min_length=1)
+    timeout_seconds: PositiveInt = 5
+
+
+AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig | ConfigTamperAttackConfig
 
 
 class AttackFile(BaseModel):

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from capex.attacks import impact
+from capex.models import ConfigTamperAttackConfig, DeviceConfig
+
+
+class _FakeTcpSocket:
+    def __init__(self, *, recv_data: bytes = b'HTTP/1.1 403 Forbidden\r\n') -> None:
+        self._recv_data = recv_data
+        self.sent: bytes = b''
+
+    def settimeout(self, timeout: float) -> None:
+        pass
+
+    def sendall(self, data: bytes) -> None:
+        self.sent = data
+
+    def recv(self, bufsize: int) -> bytes:
+        return self._recv_data
+
+    def __enter__(self) -> _FakeTcpSocket:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        pass
+
+
+def test_config_tamper_attack_defaults_to_disabled() -> None:
+    attack = ConfigTamperAttackConfig(
+        name='config_tamper',
+        label='Config_Tamper',
+        path='/setup.cgi',
+        body='ssid=pwned',
+    )
+    assert attack.enabled is False
+
+
+def test_config_tamper_executor_sends_request_and_returns_status(monkeypatch) -> None:
+    fake_socket = _FakeTcpSocket(recv_data=b'HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n')
+    monkeypatch.setattr(impact.socket, 'create_connection', lambda address, timeout: fake_socket)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = ConfigTamperAttackConfig(
+        name='config_tamper',
+        label='Config_Tamper',
+        port=80,
+        path='/setup.cgi',
+        body='ssid=pwned&password=pwned',
+    )
+    executor = impact.ConfigTamperExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == "response='HTTP/1.1 403 Forbidden'"
+    assert fake_socket.sent == (
+        b'POST /setup.cgi HTTP/1.1\r\n'
+        b'Host: 192.168.1.1\r\n'
+        b'Content-Type: application/x-www-form-urlencoded\r\n'
+        b'Content-Length: 25\r\n'
+        b'Connection: close\r\n\r\n'
+        b'ssid=pwned&password=pwned'
+    )
+
+
+def test_config_tamper_executor_returns_unreachable_on_connection_failure(monkeypatch) -> None:
+    def refuse(address, timeout):
+        raise ConnectionRefusedError
+
+    monkeypatch.setattr(impact.socket, 'create_connection', refuse)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = ConfigTamperAttackConfig(name='config_tamper', label='Config_Tamper', path='/setup.cgi', body='x=1')
+    executor = impact.ConfigTamperExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'response=<unreachable>'
+
+
+def test_config_tamper_executor_returns_no_response_on_timeout(monkeypatch) -> None:
+    class _TimingOutSocket(_FakeTcpSocket):
+        def recv(self, bufsize: int) -> bytes:
+            raise TimeoutError
+
+    fake_socket = _TimingOutSocket()
+    monkeypatch.setattr(impact.socket, 'create_connection', lambda address, timeout: fake_socket)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = ConfigTamperAttackConfig(name='config_tamper', label='Config_Tamper', path='/setup.cgi', body='x=1')
+    executor = impact.ConfigTamperExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'response=<no response>'

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -6,9 +6,10 @@ import pytest
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
 from capex.attacks.hulk import HulkAttackExecutor
+from capex.attacks.impact import ConfigTamperExecutor
 from capex.attacks.registry import AttackRegistry
 from capex.exceptions import RegistryError
-from capex.models import CommandAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
+from capex.models import CommandAttackConfig, ConfigTamperAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
 from capex.runner import CommandRunner
 
 
@@ -45,6 +46,18 @@ def test_registry_resolves_hulk_attack() -> None:
     )
     resolved = registry.resolve(attack)
     assert isinstance(resolved, HulkAttackExecutor)
+
+
+def test_registry_resolves_config_tamper_attack() -> None:
+    registry = AttackRegistry(CommandRunner())
+    attack = ConfigTamperAttackConfig(
+        name='config_tamper',
+        label='Config_Tamper',
+        path='/setup.cgi',
+        body='x=1',
+    )
+    resolved = registry.resolve(attack)
+    assert isinstance(resolved, ConfigTamperExecutor)
 
 
 def test_registry_raises_registry_error_for_unsupported_kind() -> None:


### PR DESCRIPTION
Part of the attack-library expansion roadmap in #66. Resolves #80.

## Summary
- New native executor `ConfigTamperExecutor` (`kind: config_tamper`): sends a real, protocol-correct HTTP request (configurable `path`/`method`/`body`) and reports the response status line.
- Safety: defaults to `enabled: false` **at the model level** (`ConfigTamperAttackConfig.enabled` defaults `False`, unlike every other attack kind which defaults `True`), and the `config_tamper_setup_cgi` entry in `attacks.yaml` is also explicitly `enabled: false` with a comment explaining why.
- The executor is fully implemented and tested — it's ready to enable once a specific path/body has been vetted against a specific device. I don't have per-device vetting data to draw on, so I left it inert rather than guess at what's safe to actually fire at real hardware.

MITRE: T1489 Service Stop, T1565 Data Manipulation.

## Test plan
- [x] `uv run pytest` — full suite green (93 tests)
- [x] `uv run pytest --cov=capex` — `impact.py` and `registry.py` both 100%
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run capex --dry-run` — confirms `configs/attacks.yaml` loads/validates; entry appears in the plan listing but the real run loop filters on `enabled`, so it won't fire

I'll merge this manually; will close #80 with a comment linking the merge afterward.