### PR TITLE
feat: Mirai telnet default-credential brute force attack

### DIFF
--- a/configs/attacks.yaml
+++ b/configs/attacks.yaml
@@ -75,6 +75,30 @@ attacks:
     max_attempts: 6
     tasks: 1
 
+  # Credential Access #2 (#91) - real entries from Mirai's published
+  # default-credential table (all root:X pairs below are literal entries
+  # from that table, not a synthesized cartesian product).
+  - name: hydra_telnet_mirai_creds
+    label: Hydra_Telnet_Mirai_Creds
+    kind: hydra_brute_force
+    enabled: true
+    repeats: 3
+    service: telnet
+    port: 23
+    username_list:
+      - root
+    password_list:
+      - xc3511
+      - vizxv
+      - admin
+      - "888888"
+      - xmhdipc
+      - default
+      - juantech
+      - "54321"
+    max_attempts: 8
+    tasks: 1
+
   # - name: http_request
   #   label: HTTP_Request
   #   enabled: false


### PR DESCRIPTION
Second Credential Access example per #66's >= 2-examples-per-category bar. Resolves #91.

## Note: depends on #76
This branch is built on top of `credaccess/76-hydra-brute-force` (PR #84, not yet merged) since it reuses `HydraBruteForceExecutor`/`HydraBruteForceAttackConfig` from that PR. **The diff below will include #76's commit until #84 merges** — once #84 merges to `dev`, I'll rebase this branch so the diff shrinks to just the new config entry. No need to review #76's code again here.

## Summary
- New `hydra_telnet_mirai_creds` entry in `attacks.yaml` (`kind: hydra_brute_force`, no new code — reuses #76's executor) targeting telnet/23.
- Every `username:password` pair (`root:xc3511`, `root:vizxv`, `root:admin`, `root:888888`, `root:xmhdipc`, `root:default`, `root:juantech`, `root:54321`) is a literal entry from Mirai's published default-credential table — not a synthesized cartesian product, so no fabricated pairs get attempted (the executor's `username_list` is just `[root]`, so `username_list × password_list` only ever produces real `root:X` pairs from the actual table).

MITRE: T1110 Brute Force, T1078.001 Default Accounts.

## Test plan
- [x] `uv run pytest` — full suite green, unchanged (no new Python code)
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run capex --dry-run` — confirms `configs/attacks.yaml` loads/validates with the new entry

I'll merge this manually; will close #91 with a comment linking the merge afterward.