### PR TITLE
feat: DNS-based C2 beacon attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Each attack is defined by a `kind` field and mapped to an executor:
 * `command` executes external binaries such as `nmap` or `hping3`
 * `hulk` runs an in-process HTTP flood (HULK) against the target device; configurable via `duration_seconds` and `thread_count`
 * `c2_beacon` sends a single jittered check-in request per invocation, mimicking botnet C2 callback traffic; configurable via `port`, `path`, and `jitter_seconds`
+* `c2_dns_beacon` sends a single jittered real DNS query per invocation as a C2 check-in beacon over UDP/53, distinct wire shape from `c2_beacon`; configurable via `port`, `domain`, and `jitter_seconds`
 * `placeholder` is a disabled stub for attacks not yet implemented (cannot be `enabled: true`)
 * additional attack types can be added via the registry
 

--- a/configs/attacks.yaml
+++ b/configs/attacks.yaml
@@ -68,6 +68,17 @@ attacks:
     jitter_seconds: 5
     timeout_seconds: 5
 
+  # Lateral Movement / C2 #2 (#92)
+  - name: c2_dns_beacon
+    label: C2_DNS_Beacon
+    kind: c2_dns_beacon
+    enabled: true
+    repeats: 5
+    port: 53
+    domain: update-check.example
+    jitter_seconds: 5
+    timeout_seconds: 5
+
   # - name: http_request
   #   label: HTTP_Request
   #   enabled: false

--- a/src/capex/attacks/c2_dns.py
+++ b/src/capex/attacks/c2_dns.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import random
+import socket
+import time
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from capex.models import C2DnsBeaconAttackConfig, DeviceConfig
+
+_DNS_RECV_BUFFER = 512
+
+_QUERY_FLAGS = b'\x01\x00'
+_QDCOUNT = b'\x00\x01'
+_ZERO_COUNTS = b'\x00\x00\x00\x00\x00\x00'
+_QTYPE_A_QCLASS_IN = b'\x00\x01\x00\x01'
+
+
+def _encode_qname(domain: str) -> bytes:
+    encoded = b''
+    for label in domain.split('.'):
+        label_bytes = label.encode('ascii')
+        encoded += len(label_bytes).to_bytes(1, 'big') + label_bytes
+    return encoded + b'\x00'
+
+
+def build_dns_query(*, domain: str, query_id: int) -> bytes:
+    header = query_id.to_bytes(2, 'big') + _QUERY_FLAGS + _QDCOUNT + _ZERO_COUNTS
+    question = _encode_qname(domain) + _QTYPE_A_QCLASS_IN
+    return header + question
+
+
+class DnsC2BeaconExecutor:
+    """Sends a single real DNS query as a jittered C2 check-in beacon.
+
+    Distinct wire shape from the HTTP beacon (c2.py) - small periodic
+    UDP/53 queries rather than TCP/80 requests - while representing the
+    same post-compromise callback behavior (T1071.004).
+    """
+
+    def __init__(self, *, attack: C2DnsBeaconAttackConfig) -> None:
+        self._attack = attack
+
+    def execute(self, *, device: DeviceConfig) -> str | None:
+        if self._attack.jitter_seconds:
+            time.sleep(random.uniform(0, self._attack.jitter_seconds))
+
+        query_id = random.randint(0, 0xFFFF)
+        message = build_dns_query(domain=self._attack.domain, query_id=query_id)
+
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.settimeout(self._attack.timeout_seconds)
+            sock.sendto(message, (str(device.ip), self._attack.port))
+
+            try:
+                sock.recvfrom(_DNS_RECV_BUFFER)
+                responded = True
+            except TimeoutError:
+                responded = False
+
+        return f'beacon=sent, responded={responded}'

--- a/src/capex/attacks/registry.py
+++ b/src/capex/attacks/registry.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
 from capex.attacks.c2 import C2BeaconExecutor
+from capex.attacks.c2_dns import DnsC2BeaconExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.exceptions import RegistryError
 
@@ -34,6 +35,10 @@ class AttackRegistry:
                 )
             case 'c2_beacon':
                 return C2BeaconExecutor(
+                    attack=attack,
+                )
+            case 'c2_dns_beacon':
+                return DnsC2BeaconExecutor(
                     attack=attack,
                 )
             case _:

--- a/src/capex/models.py
+++ b/src/capex/models.py
@@ -62,7 +62,23 @@ class C2BeaconAttackConfig(BaseModel):
     timeout_seconds: PositiveInt = 5
 
 
-AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig | C2BeaconAttackConfig
+class C2DnsBeaconAttackConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    kind: Literal['c2_dns_beacon'] = 'c2_dns_beacon'
+    name: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    enabled: bool = True
+    repeats: PositiveInt = 5
+    port: PositiveInt = 53
+    domain: str = 'update-check.example'
+    jitter_seconds: NonNegativeInt = 5
+    timeout_seconds: PositiveInt = 5
+
+
+AttackConfig = (
+    CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig | C2BeaconAttackConfig | C2DnsBeaconAttackConfig
+)
 
 
 class AttackFile(BaseModel):

--- a/tests/test_c2_dns.py
+++ b/tests/test_c2_dns.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from capex.attacks import c2_dns
+from capex.models import C2DnsBeaconAttackConfig, DeviceConfig
+
+
+class _FakeUdpSocket:
+    def __init__(self, *, response: bytes | None = b'\x00' * 12) -> None:
+        self._response = response
+        self.sent: list[tuple[bytes, tuple[str, int]]] = []
+
+    def settimeout(self, timeout: float) -> None:
+        pass
+
+    def sendto(self, data: bytes, address: tuple[str, int]) -> None:
+        self.sent.append((data, address))
+
+    def recvfrom(self, bufsize: int) -> tuple[bytes, tuple[str, int]]:
+        if self._response is None:
+            raise TimeoutError
+        return self._response, ('192.168.1.1', 53)
+
+    def __enter__(self) -> _FakeUdpSocket:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        pass
+
+
+def test_build_dns_query_produces_valid_wire_format() -> None:
+    message = c2_dns.build_dns_query(domain='update-check.example', query_id=0x1234)
+
+    header = b'\x12\x34\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00'
+    qname = b'\x0cupdate-check\x07example\x00'
+    question_tail = b'\x00\x01\x00\x01'
+
+    assert message == header + qname + question_tail
+
+
+def test_dns_beacon_executor_sends_query_and_reports_response(monkeypatch) -> None:
+    fake_socket = _FakeUdpSocket(response=b'\x12\x34' + b'\x00' * 10)
+    monkeypatch.setattr(c2_dns.socket, 'socket', lambda *args, **kwargs: fake_socket)
+    monkeypatch.setattr(c2_dns.random, 'randint', lambda a, b: 0x1234)
+    monkeypatch.setattr(c2_dns.random, 'uniform', lambda a, b: 0.0)
+    monkeypatch.setattr(c2_dns.time, 'sleep', lambda seconds: None)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = C2DnsBeaconAttackConfig(name='c2_dns_beacon', label='C2_DNS_Beacon', domain='update-check.example')
+    executor = c2_dns.DnsC2BeaconExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'beacon=sent, responded=True'
+    sent_data, address = fake_socket.sent[0]
+    assert address == ('192.168.1.1', 53)
+    assert sent_data == c2_dns.build_dns_query(domain='update-check.example', query_id=0x1234)
+
+
+def test_dns_beacon_executor_reports_no_response_on_timeout(monkeypatch) -> None:
+    fake_socket = _FakeUdpSocket(response=None)
+    monkeypatch.setattr(c2_dns.socket, 'socket', lambda *args, **kwargs: fake_socket)
+    monkeypatch.setattr(c2_dns.random, 'randint', lambda a, b: 0x1234)
+    monkeypatch.setattr(c2_dns.time, 'sleep', lambda seconds: None)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = C2DnsBeaconAttackConfig(name='c2_dns_beacon', label='C2_DNS_Beacon', jitter_seconds=0)
+    executor = c2_dns.DnsC2BeaconExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'beacon=sent, responded=False'
+
+
+def test_dns_beacon_executor_applies_jitter_before_sending(monkeypatch) -> None:
+    fake_socket = _FakeUdpSocket()
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(c2_dns.socket, 'socket', lambda *args, **kwargs: fake_socket)
+    monkeypatch.setattr(c2_dns.random, 'randint', lambda a, b: 0x1234)
+    monkeypatch.setattr(c2_dns.random, 'uniform', lambda a, b: 2.5)
+    monkeypatch.setattr(c2_dns.time, 'sleep', lambda seconds: sleep_calls.append(seconds))
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = C2DnsBeaconAttackConfig(name='c2_dns_beacon', label='C2_DNS_Beacon', jitter_seconds=5)
+    executor = c2_dns.DnsC2BeaconExecutor(attack=attack)
+
+    executor.execute(device=device)
+
+    assert sleep_calls == [2.5]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from ipaddress import IPv4Address
 
-from capex.models import C2BeaconAttackConfig, CommandAttackConfig, DeviceConfig
+from capex.models import C2BeaconAttackConfig, C2DnsBeaconAttackConfig, CommandAttackConfig, DeviceConfig
 
 
 def test_device_config_validates() -> None:
@@ -23,3 +23,9 @@ def test_c2_beacon_attack_config_defaults() -> None:
     attack = C2BeaconAttackConfig(name='c2_beacon', label='C2_Beacon')
     assert attack.jitter_seconds == 5
     assert attack.path == '/'
+
+
+def test_c2_dns_beacon_attack_config_defaults() -> None:
+    attack = C2DnsBeaconAttackConfig(name='c2_dns_beacon', label='C2_DNS_Beacon')
+    assert attack.port == 53
+    assert attack.domain == 'update-check.example'

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -6,10 +6,17 @@ import pytest
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
 from capex.attacks.c2 import C2BeaconExecutor
+from capex.attacks.c2_dns import DnsC2BeaconExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.attacks.registry import AttackRegistry
 from capex.exceptions import RegistryError
-from capex.models import C2BeaconAttackConfig, CommandAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
+from capex.models import (
+    C2BeaconAttackConfig,
+    C2DnsBeaconAttackConfig,
+    CommandAttackConfig,
+    HulkAttackConfig,
+    PlaceholderAttackConfig,
+)
 from capex.runner import CommandRunner
 
 
@@ -53,6 +60,13 @@ def test_registry_resolves_c2_beacon_attack() -> None:
     attack = C2BeaconAttackConfig(name='c2_beacon', label='C2_Beacon')
     resolved = registry.resolve(attack)
     assert isinstance(resolved, C2BeaconExecutor)
+
+
+def test_registry_resolves_c2_dns_beacon_attack() -> None:
+    registry = AttackRegistry(CommandRunner())
+    attack = C2DnsBeaconAttackConfig(name='c2_dns_beacon', label='C2_DNS_Beacon')
+    resolved = registry.resolve(attack)
+    assert isinstance(resolved, DnsC2BeaconExecutor)
 
 
 def test_registry_raises_registry_error_for_unsupported_kind() -> None:


### PR DESCRIPTION
Second Lateral Movement/C2 example per #66's >= 2-examples-per-category bar. Resolves #92.

## Note: depends on #78
Built on top of `c2/78-beacon-simulation` (PR #86, not yet merged), so the diff below includes #78's commit until #86 merges. Will rebase to shrink the diff once #86 lands. No need to review #78's code again here.

## Summary
- New native executor `DnsC2BeaconExecutor` (`kind: c2_dns_beacon`) plus a small `build_dns_query()` helper that hand-builds a real, valid DNS wire-format query (header + QNAME + QTYPE A/QCLASS IN) — no synthetic/fake protocol bytes.
- Sends one jittered query per invocation via UDP/53, same jitter approach as #78's HTTP beacon. Doesn't require the device to run a real resolver or answer correctly — per #66's framing this is *simulated* beacon traffic, so an unanswered query is handled gracefully (`responded=False`) rather than treated as an error.
- Distinct wire shape from #78's HTTP beacon (small periodic UDP/53 queries vs. TCP/80 requests) — gives the multiclass detector two genuinely different C2 traffic-class signatures for the same MITRE technique family.
- New `c2_dns_beacon` entry in `attacks.yaml`.

MITRE: T1071.004 Application Layer Protocol: DNS.

## Test plan
- [x] `uv run pytest` — full suite green (101 tests)
- [x] `uv run pytest --cov=capex` — `c2_dns.py` and `registry.py` both 100%
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run capex --dry-run` — confirms `configs/attacks.yaml` loads/validates with the new entry
- [x] dedicated test asserts the exact DNS query byte layout is valid wire format

I'll merge this manually; will close #92 with a comment linking the merge afterward.